### PR TITLE
changed status form disabled to okay for uart[234]

### DIFF
--- a/blobs/pine64.dts
+++ b/blobs/pine64.dts
@@ -1532,7 +1532,7 @@
             pinctrl-1 = <0x00000020>;
             uart2_port = <0x00000002>;
             uart2_type = <0x00000004>;
-            status = "disabled";
+            status = "okay";
             pinctrl-0 = <0x000000a4>;
         };
         uart@01c28c00 {
@@ -1545,7 +1545,7 @@
             pinctrl-1 = <0x00000023>;
             uart3_port = <0x00000003>;
             uart3_type = <0x00000004>;
-            status = "disabled";
+            status = "okay";
             pinctrl-0 = <0x000000a5>;
         };
         uart@01c29000 {
@@ -1558,7 +1558,7 @@
             pinctrl-1 = <0x00000026>;
             uart4_port = <0x00000004>;
             uart4_type = <0x00000004>;
-            status = "disabled";
+            status = "okay";
             pinctrl-0 = <0x000000a6>;
         };
         twi@0x01c2ac00 {


### PR DESCRIPTION
Changed status form disabled to okay for uart@01c28800(uart2) uart@01c28c00(uart3), uart@01c29000(uart4). Credits go to @martinayotte (http://forum.pine64.org/showthread.php?tid=648). I was able to confirm a serial connection for uart2 and uart4(EULER pin 19,21) but failed with uart3(EULER pin 23,24). May be someone with a multimeter might conduct further investigation and find the right pins.
