### PR TITLE
Fix eth0-mackeeper.service creation

### DIFF
--- a/simpleimage/make_rootfs.sh
+++ b/simpleimage/make_rootfs.sh
@@ -113,11 +113,10 @@ add_mackeeper_service() {
 	cat > "$DEST/etc/systemd/system/eth0-mackeeper.service" <<EOF
 [Unit]
 Description=Fix eth0 mac address to uEnv.txt
+After=systemd-modules-load.service local-fs.target
 
 [Service]
 Type=oneshot
-After=systemd-modules-load.service
-After=local-fs.target
 ExecStart=/usr/local/sbin/pine64_eth0-mackeeper.sh
 
 [Install]


### PR DESCRIPTION
There's no After= option in Service section and systemd complains about
it during boot. Move this option to Unit section and convert it to
space-separated list according to documentation.
