### PR TITLE
Reading rootfs partition from kernel parameter 'root'

### DIFF
--- a/kernel/make_initrd.sh
+++ b/kernel/make_initrd.sh
@@ -23,7 +23,7 @@ cp -va $BUSYBOX/busybox $TEMP/bin
 cd $TEMP
 mkdir dev proc sys tmp sbin
 mknod dev/console c 5 1
-cat > $TEMP/init <<EOF
+cat > $TEMP/init <<'EOF'
 #!/bin/busybox sh
 
 # Install busybox
@@ -34,28 +34,58 @@ mount -t proc none /proc
 mount -t sysfs none /sys
 mount -t devtmpfs none /dev
 
-sleep 1
+cmdline() {
+        local value
+        value=" $(cat /proc/cmdline) "
+        value="${value##* $1=}"
+        value="${value%% *}"
+        [ "$value" != "" ] && echo "$value"
+}
 
-if [ -e /dev/mmcblk0p2 ]; then
-	# Mount real root.
-	mkdir -p /mnt/root
-	mount -o rw /dev/mmcblk0p2 /mnt/root
+realboot() {
+        echo "Rootfs: $1";
+        # Mount real root.
+        mkdir -p /mnt/root
+        mount -o rw "$1" /mnt/root
 
-	if [ -x /mnt/root/sbin/init -o -h /mnt/root/sbin/init ]; then
-		# Cleanup.
-		umount /proc
-		umount /sys
-		umount /dev
+        if [ -x /mnt/root/sbin/init -o -h /mnt/root/sbin/init ]; then
+                # Cleanup.
+                umount /proc
+                umount /sys
+                umount /dev
 
-		# Boot the real system.
-		exec switch_root /mnt/root /sbin/init
-	fi
+                # Boot the real system.
+                exec switch_root /mnt/root /sbin/init
+        else
+                umount /mnt/root
+        fi
+}
 
-fi
+runshell() {
+        echo "Dropping to a shell."
+        echo
+        setsid cttyhack /bin/sh
+}
 
-echo "Dropping to a shell."
-echo
-setsid cttyhack /bin/sh
+boot() {
+        echo "Kernel params: `cat /proc/cmdline`"
+        timeout=20;
+
+        while [ "$timeout" -ge 1 ]; do
+                echo "Waiting for root system $(cmdline root), countdown : $timeout";
+                if [ -e $(cmdline root) ]; then
+                        realboot $(cmdline root);
+                fi;
+
+                timeout=$(( $timeout - 1 ));
+                sleep 1;
+        done;
+
+        # Default rootfs - sd partition 2
+        realboot /dev/mmcblk0p2;
+        runshell;
+}
+boot;
 EOF
 chmod 755 $TEMP/init
 

--- a/kernel/make_initrd.sh
+++ b/kernel/make_initrd.sh
@@ -69,12 +69,13 @@ runshell() {
 
 boot() {
         echo "Kernel params: `cat /proc/cmdline`"
-        timeout=20;
+        local timeout=20;
+        local kernel_root_param=$(cmdline root)
 
         while [ "$timeout" -ge 1 ]; do
-                echo "Waiting for root system $(cmdline root), countdown : $timeout";
-                if [ -e $(cmdline root) ]; then
-                        realboot $(cmdline root);
+                echo "Waiting for root system $kernel_root_param, countdown : $timeout";
+                if [ -e "$kernel_root_param" ]; then
+                        realboot $kernel_root_param;
                 fi;
 
                 timeout=$(( $timeout - 1 ));


### PR DESCRIPTION
Small improvements to init script. This will allow to set root partition in uEnv.txt. Script waits 20 second for the partition, if it doesn't show up it tries to boot from sd card (/dev/mmcblk0p2).

Sample uEnv.txt

```
console=tty0 console=ttyS0,115200n8 no_console_suspend
kernel_filename=pine64/Image
initrd_filename=initrdwait.img 
root=/dev/sdb2
ethaddr=##:##:##:##:##:##
```

UART output

```
[  172.346109] Freeing unused kernel memory: 492K (ffffffc00097a000 - ffffffc0009f5000)
Kernel params: console=tty0 console=ttyS0,115200n8 no_console_suspend earlycon=uart,mmio32,0x01c28000 mac_addr=##:##:##:##:##:## root=/dev/sdb2 ro rootwait
Waiting for root system /dev/sdb2, countdown : 20
[  172.468887]
[  172.468887]
[.....]
[  172.976050] scene_lock_init name=ohci_standby
[  172.986656] host_chose finished 86!
Waiting for root system /dev/sdb2, countdown : 19
Waiting for root system /dev/sdb2, countdown : 18
Waiting for root system /dev/sdb2, countdown : 17
Waiting for root system /dev/sdb2, countdown : 16
Waiting for root system /dev/sdb2, countdown : 15
[  177.438461] scsi 1:0:0:0: Direct-Access     ATA      HGST HTS541010A9 A560 PQ: 0 ANSI: 6
[  177.454878] sd 1:0:0:0: [sdb] 1953525168 512-byte logical blocks: (1.00 TB/931 GiB)
[  177.470117] sd 1:0:0:0: [sdb] Write Protect is off
[  177.482171] sd 1:0:0:0: [sdb] Write cache: disabled, read cache: enabled, doesn't support DPO or FUA
[  177.559890]  sdb: sdb1 sdb2 sdb3 sdb4 sdb5 sdb6
[  177.576276] sd 1:0:0:0: [sdb] Attached SCSI disk
Waiting for root system /dev/sdb2, countdown : 14
Rootfs: /dev/sdb2
Welcome to Ubuntu 16.04 LTS!
```
