### PR TITLE
Using blkid to find the root partition

### DIFF
--- a/kernel/make_initrd.sh
+++ b/kernel/make_initrd.sh
@@ -67,19 +67,24 @@ runshell() {
         setsid cttyhack /bin/sh
 }
 
+find_parition_by_value() {
+        echo `blkid | tr -d '"' | grep "$1" | cut -d ':' -f 1 | head -n 1`
+}
+
 boot() {
         echo "Kernel params: `cat /proc/cmdline`"
-        local timeout=20;
+        local i=5
         local kernel_root_param=$(cmdline root)
 
-        while [ "$timeout" -ge 1 ]; do
-                echo "Waiting for root system $kernel_root_param, countdown : $timeout";
-                if [ -e "$kernel_root_param" ]; then
-                        realboot $kernel_root_param;
+        while [ "$i" -ge 1 ]; do
+                echo "Waiting for root system $kernel_root_param, countdown : $i";
+                local root=`find_parition_by_value $kernel_root_param`
+                if [ -e "$root" ]; then
+                        realboot $root;
                 fi;
 
-                timeout=$(( $timeout - 1 ));
-                sleep 1;
+                i=$(( $i - 1 ));
+                sleep 5;
         done;
 
         # Default rootfs - sd partition 2


### PR DESCRIPTION
I added code that allows to find root fs by UUID, dev name, part of UUID, label etc.. It uses blkid and grep to find first matching line. It fixes the problem when external usb drivers have different dev names at each boot.

Example

blkid result

```
/dev/mmcblk0p1: SEC_TYPE="msdos" LABEL="BOOT" UUID="99A5-0B82" TYPE="vfat" PARTUUID="dce985d5-01"

/dev/sdb1: UUID="bacbe791-b2b9-4968-93a7-fdb3e2401b5c" TYPE="ext4" PARTLABEL="Linux filesystem" PARTUUID="961bd748-72e8-4726-a99b-e5f18de7b856"

/dev/sdb2: UUID="c5d4d4c5-96bb-4fcc-914e-0d48ddb9a34a" TYPE="ext4" PARTUUID="d8a3fb0f-5c91-47b9-b570-d1beeb1c99da"

/dev/sdb3: LABEL="ROOT_DEFAULT" UUID="93baa030-14ae-46cd-8cd4-e54daa633cf3" TYPE="ext4" PARTUUID="37795dd4-5843-483f-bb68-780a9ab36364"

/dev/sdb4: LABEL="HOME" UUID="5773aad3-da21-4b3d-886e-a6a7ccac9d9c" TYPE="ext4" PARTLABEL="Linux filesystem" PARTUUID="fafe56f9-1faa-42e5-8efa-878804b19936"

/dev/sdb5: LABEL="PART0" UUID="15c4bcc6-facb-4f0f-b1ee-fe806e291507" TYPE="ext4" PARTUUID="917df41c-e0cd-47bf-a882-4c2ae7715e91"

/dev/sdb6: LABEL="PART1" UUID="ad431f3c-27b7-43e5-ae7d-35fb789e9751" TYPE="ext4" PARTLABEL="Linux filesystem" PARTUUID="4af666e8-ea6b-420e-849f-547a1d9ed905"
```

To choose /dev/sdb3 we can set uEnv like this
1. `root=UUID="93baa030-14ae-46cd-8cd4-e54daa633cf3"`
2. `root=LABEL="ROOT_DEFAULT"`
3. `root=ROOT_DEFAULT`
4. `root=14ae-46cd-8cd4-e54daa633cf3`
5. `root=sdb3`
etc..
