### PR TITLE
Add ARCH and CROSS_COMPILE in Mali build command

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -80,7 +80,7 @@ The BSP Kernel tree also contains the graphics driver in `modules/gpu`.
 
 ```
 cd modules/gpu
-LICHEE_KDIR=$(pwd)/../.. LICHEE_PLATFORM=Pine64 make build
+LICHEE_KDIR=$(pwd)/../.. ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- LICHEE_PLATFORM=Pine64 make build
 ```
 
 This will compile the mali.ko Kernel module with the Kernel .config found in


### PR DESCRIPTION
If ARCH and CROSS_COMPILE are not set, the make build for the Mali kernel module fails

eddy@feodora:~/usr/src/linux/modules/gpu$ LICHEE_KDIR=$(pwd)/../.. LICHEE_PLATFORM=Pine64 make build
make -j -C mali400/kernel_mode/driver/src/devicedrv/mali BUILD=release KERNELDIR=/home/eddy/usr/src/linux/modules/gpu/../..
make[1]: Entering directory '/home/eddy/usr/src/linux/modules/gpu/mali400/kernel_mode/driver/src/devicedrv/mali'
make ARCH= -C /home/eddy/usr/src/linux/modules/gpu/../.. M=/home/eddy/usr/src/linux/modules/gpu/mali400/kernel_mode/driver/src/devicedrv/mali modules
make[2]: Entering directory '/home/eddy/usr/src/linux'
Makefile:579: /home/eddy/usr/src/linux/arch//Makefile: No such file or directory
make[2]: **\* No rule to make target '/home/eddy/usr/src/linux/arch//Makefile'. Stop.
make[2]: Leaving directory '/home/eddy/usr/src/linux'
Makefile:174: recipe for target 'all' failed
make[1]: **\* [all] Error 2
make[1]: Leaving directory '/home/eddy/usr/src/linux/modules/gpu/mali400/kernel_mode/driver/src/devicedrv/mali'
Makefile:94: recipe for target 'build' failed
make: **\* [build] Error 2

We recommend adding them for module build, too.

Signed-off-by: Eddy Petrișor eddy.petrisor@gmail.com
