### PR TITLE
Don't advise to use Debian Installer initrd

### DIFF
--- a/kernel/make_initrd.sh
+++ b/kernel/make_initrd.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 #
 # Simple script to create a small busybox based initrd. It requires a compiled
-# busybox static binary. You can also use any other initrd for example one
-# from Debian like # https://d-i.debian.org/daily-images/arm64/20160206-00:06/netboot/debian-installer/arm64/
+# busybox static binary. You can also use any other prebuilt initrd.
+#
+# Please note that some prebuilt initrd-s might inappropriate, for example, the
+# ones from the Debian Installer will start an install process, so don't use those.
 #
 # Run this script with fakeroot or as root.
 


### PR DESCRIPTION
The Debian Installer initrd-s are special purpose and will start the debian
installer instead of allowing the use of a prebuilt rootfs. Remove the hint of
using them because of that.

Signed-off-by: Eddy Petrișor eddy.petrisor@gmail.com
