### PR TITLE
Fix image build timestamp

### DIFF
--- a/build-pine64-image.sh
+++ b/build-pine64-image.sh
@@ -35,7 +35,7 @@ SIMPLEIMAGE=$(readlink -f "$SIMPLEIMAGE")
 KERNELTAR=$(readlink -f "$KERNELTAR")
 
 SIZE=3650 # MiB
-DATE=$(date +%Y%m%H)
+DATE=$(date +%Y%m%d_%H%M%S_%Z)
 
 PWD=$(readlink -f .)
 TEMP=$(mktemp -p $PWD -d -t "pine64-build-XXXXXXXXXX")


### PR DESCRIPTION
The current usage of date seems a bit odd. Currently it's "year month hour". On purpose?