### PR TITLE
Major enhancements to the build tools

### DIFF
--- a/blobs/pine64lcd.dts
+++ b/blobs/pine64lcd.dts
@@ -1,0 +1,3435 @@
+/dts-v1/;
+
+/memreserve/	0x0000000045000000 0x0000000000200000;
+/memreserve/	0x0000000041010000 0x0000000000010000;
+/memreserve/	0x0000000041020000 0x0000000000000800;
+/memreserve/	0x0000000040100000 0x0000000000004000;
+/memreserve/	0x0000000040104000 0x0000000000001000;
+/memreserve/	0x0000000040105000 0x0000000000001000;
+/ {
+	model = "sun50iw1p1";
+	compatible = "arm,sun50iw1p1", "arm,sun50iw1p1";
+	interrupt-parent = <0x1>;
+	#address-cells = <0x2>;
+	#size-cells = <0x2>;
+
+	clocks {
+		compatible = "allwinner,sunxi-clk-init";
+		device_type = "clocks";
+		#address-cells = <0x2>;
+		#size-cells = <0x2>;
+		ranges;
+		reg = <0x0 0x1c20000 0x0 0x320 0x0 0x1f01400 0x0 0xb0 0x0 0x1f00060 0x0 0x4>;
+
+		losc {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-clock";
+			clock-frequency = <0x8000>;
+			clock-output-names = "losc";
+			linux,phandle = <0xc>;
+			phandle = <0xc>;
+		};
+
+		iosc {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-clock";
+			clock-frequency = <0xf42400>;
+			clock-output-names = "iosc";
+			linux,phandle = <0xd>;
+			phandle = <0xd>;
+		};
+
+		hosc {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-clock";
+			clock-frequency = <0x16e3600>;
+			clock-output-names = "hosc";
+			linux,phandle = <0x6>;
+			phandle = <0x6>;
+		};
+
+		pll_cpu {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_cpu";
+		};
+
+		pll_audio {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			assigned-clock-rates = <0x1770000>;
+			clock-output-names = "pll_audio";
+			linux,phandle = <0x2>;
+			phandle = <0x2>;
+		};
+
+		pll_video0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			assigned-clock-rates = <0x11b3dc40>;
+			clock-output-names = "pll_video0";
+			linux,phandle = <0x3>;
+			phandle = <0x3>;
+		};
+
+		pll_ve {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_ve";
+			linux,phandle = <0x16>;
+			phandle = <0x16>;
+		};
+
+		pll_ddr0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_ddr0";
+			linux,phandle = <0x93>;
+			phandle = <0x93>;
+		};
+
+		pll_periph0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_periph0";
+			linux,phandle = <0x4>;
+			phandle = <0x4>;
+		};
+
+		pll_periph1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_periph1";
+			linux,phandle = <0x5>;
+			phandle = <0x5>;
+		};
+
+		pll_video1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			assigned-clock-rates = <0x11b3dc40>;
+			clock-output-names = "pll_video1";
+		};
+
+		pll_gpu {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_gpu";
+			linux,phandle = <0x96>;
+			phandle = <0x96>;
+		};
+
+		pll_mipi {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_mipi";
+			linux,phandle = <0x8>;
+			phandle = <0x8>;
+		};
+
+		pll_hsic {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_hsic";
+			linux,phandle = <0x3a>;
+			phandle = <0x3a>;
+		};
+
+		pll_de {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			assigned-clock-rates = <0x11b3dc40>;
+			clock-output-names = "pll_de";
+			linux,phandle = <0x7>;
+			phandle = <0x7>;
+		};
+
+		pll_ddr1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-pll-clock";
+			lock-mode = "new";
+			clock-output-names = "pll_ddr1";
+			linux,phandle = <0x94>;
+			phandle = <0x94>;
+		};
+
+		pll_audiox8 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-factor-clock";
+			clocks = <0x2>;
+			clock-mult = <0x8>;
+			clock-div = <0x1>;
+			clock-output-names = "pll_audiox8";
+		};
+
+		pll_audiox4 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-factor-clock";
+			clocks = <0x2>;
+			clock-mult = <0x8>;
+			clock-div = <0x2>;
+			clock-output-names = "pll_audiox4";
+			linux,phandle = <0x3c>;
+			phandle = <0x3c>;
+		};
+
+		pll_audiox2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-factor-clock";
+			clocks = <0x2>;
+			clock-mult = <0x8>;
+			clock-div = <0x4>;
+			clock-output-names = "pll_audiox2";
+		};
+
+		pll_video0x2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-factor-clock";
+			clocks = <0x3>;
+			clock-mult = <0x2>;
+			clock-div = <0x1>;
+			clock-output-names = "pll_video0x2";
+		};
+
+		pll_periph0x2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-factor-clock";
+			clocks = <0x4>;
+			clock-mult = <0x2>;
+			clock-div = <0x1>;
+			clock-output-names = "pll_periph0x2";
+			linux,phandle = <0x7b>;
+			phandle = <0x7b>;
+		};
+
+		pll_periph1x2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-factor-clock";
+			clocks = <0x5>;
+			clock-mult = <0x2>;
+			clock-div = <0x1>;
+			clock-output-names = "pll_periph1x2";
+			linux,phandle = <0x5a>;
+			phandle = <0x5a>;
+		};
+
+		pll_periph0d2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-factor-clock";
+			clocks = <0x4>;
+			clock-mult = <0x1>;
+			clock-div = <0x2>;
+			clock-output-names = "pll_periph0d2";
+		};
+
+		hoscd2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,fixed-factor-clock";
+			clocks = <0x6>;
+			clock-mult = <0x1>;
+			clock-div = <0x2>;
+			clock-output-names = "hoscd2";
+		};
+
+		cpu {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "cpu";
+		};
+
+		cpuapb {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "cpuapb";
+		};
+
+		axi {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "axi";
+		};
+
+		pll_periphahb0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "pll_periphahb0";
+		};
+
+		ahb1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "ahb1";
+			linux,phandle = <0x95>;
+			phandle = <0x95>;
+		};
+
+		apb1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "apb1";
+		};
+
+		apb2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "apb2";
+			linux,phandle = <0x7e>;
+			phandle = <0x7e>;
+		};
+
+		ahb2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "ahb2";
+		};
+
+		ths {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "ths";
+			linux,phandle = <0x84>;
+			phandle = <0x84>;
+		};
+
+		nand {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "nand";
+			linux,phandle = <0x80>;
+			phandle = <0x80>;
+		};
+
+		sdmmc0_mod {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc0_mod";
+			linux,phandle = <0x60>;
+			phandle = <0x60>;
+		};
+
+		sdmmc0_bus {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc0_bus";
+			linux,phandle = <0x61>;
+			phandle = <0x61>;
+		};
+
+		sdmmc0_rst {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc0_rst";
+			linux,phandle = <0x62>;
+			phandle = <0x62>;
+		};
+
+		sdmmc1_mod {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc1_mod";
+			linux,phandle = <0x65>;
+			phandle = <0x65>;
+		};
+
+		sdmmc1_bus {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc1_bus";
+			linux,phandle = <0x66>;
+			phandle = <0x66>;
+		};
+
+		sdmmc1_rst {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc1_rst";
+			linux,phandle = <0x67>;
+			phandle = <0x67>;
+		};
+
+		sdmmc2_mod {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc2_mod";
+			linux,phandle = <0x5b>;
+			phandle = <0x5b>;
+		};
+
+		sdmmc2_bus {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc2_bus";
+			linux,phandle = <0x5c>;
+			phandle = <0x5c>;
+		};
+
+		sdmmc2_rst {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdmmc2_rst";
+			linux,phandle = <0x5d>;
+			phandle = <0x5d>;
+		};
+
+		ts {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "ts";
+		};
+
+		ce {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "ce";
+			linux,phandle = <0x7a>;
+			phandle = <0x7a>;
+		};
+
+		spi0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "spi0";
+			linux,phandle = <0x52>;
+			phandle = <0x52>;
+		};
+
+		spi1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "spi1";
+			linux,phandle = <0x56>;
+			phandle = <0x56>;
+		};
+
+		i2s0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "i2s0";
+			linux,phandle = <0x42>;
+			phandle = <0x42>;
+		};
+
+		i2s1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "i2s1";
+			linux,phandle = <0x47>;
+			phandle = <0x47>;
+		};
+
+		i2s2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "i2s2";
+			linux,phandle = <0x48>;
+			phandle = <0x48>;
+		};
+
+		spdif {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "spdif";
+			linux,phandle = <0x49>;
+			phandle = <0x49>;
+		};
+
+		usbphy0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbphy0";
+			linux,phandle = <0x32>;
+			phandle = <0x32>;
+		};
+
+		usbphy1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbphy1";
+			linux,phandle = <0x36>;
+			phandle = <0x36>;
+		};
+
+		usbhsic {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbhsic";
+			linux,phandle = <0x38>;
+			phandle = <0x38>;
+		};
+
+		usbhsic12m {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbhsic12m";
+			linux,phandle = <0x39>;
+			phandle = <0x39>;
+		};
+
+		usbohci1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbohci1";
+			linux,phandle = <0x3b>;
+			phandle = <0x3b>;
+		};
+
+		usbohci0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbohci0";
+			linux,phandle = <0x35>;
+			phandle = <0x35>;
+		};
+
+		de {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			assigned-clock-parents = <0x7>;
+			assigned-clock-rates = <0x11b3dc40>;
+			clock-output-names = "de";
+			linux,phandle = <0x6a>;
+			phandle = <0x6a>;
+		};
+
+		tcon0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			assigned-clock-parents = <0x8>;
+			clock-output-names = "tcon0";
+			linux,phandle = <0x6b>;
+			phandle = <0x6b>;
+		};
+
+		tcon1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			assigned-clock-parents = <0x3>;
+			clock-output-names = "tcon1";
+			linux,phandle = <0x6e>;
+			phandle = <0x6e>;
+		};
+
+		deinterlace {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "deinterlace";
+			linux,phandle = <0x7c>;
+			phandle = <0x7c>;
+		};
+
+		csi_s {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "csi_s";
+			linux,phandle = <0x73>;
+			phandle = <0x73>;
+		};
+
+		csi_m {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "csi_m";
+			linux,phandle = <0x74>;
+			phandle = <0x74>;
+		};
+
+		csi_misc {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "csi_misc";
+			linux,phandle = <0x75>;
+			phandle = <0x75>;
+		};
+
+		ve {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "ve";
+			linux,phandle = <0x17>;
+			phandle = <0x17>;
+		};
+
+		adda {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "adda";
+			linux,phandle = <0x41>;
+			phandle = <0x41>;
+		};
+
+		addax4 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "addax4";
+		};
+
+		avs {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "avs";
+		};
+
+		hdmi {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			assigned-clock-parents = <0x3>;
+			clock-output-names = "hdmi";
+			linux,phandle = <0x6f>;
+			phandle = <0x6f>;
+		};
+
+		hdmi_slow {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "hdmi_slow";
+			linux,phandle = <0x70>;
+			phandle = <0x70>;
+		};
+
+		mbus {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "mbus";
+		};
+
+		mipidsi {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "mipidsi";
+			linux,phandle = <0x6d>;
+			phandle = <0x6d>;
+		};
+
+		gpu {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "gpu";
+			linux,phandle = <0x97>;
+			phandle = <0x97>;
+		};
+
+		usbehci_16 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbohci_16";
+		};
+
+		usbehci1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbehci1";
+			linux,phandle = <0x37>;
+			phandle = <0x37>;
+		};
+
+		usbehci0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbehci0";
+			linux,phandle = <0x34>;
+			phandle = <0x34>;
+		};
+
+		usbotg {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "usbotg";
+			linux,phandle = <0x33>;
+			phandle = <0x33>;
+		};
+
+		gmac {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "gmac";
+			linux,phandle = <0x8f>;
+			phandle = <0x8f>;
+		};
+
+		sdram {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "sdram";
+		};
+
+		dma {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "dma";
+			linux,phandle = <0xb>;
+			phandle = <0xb>;
+		};
+
+		hwspinlock_rst {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "hwspinlock_rst";
+			linux,phandle = <0xf>;
+			phandle = <0xf>;
+		};
+
+		hwspinlock_bus {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "hwspinlock_bus";
+			linux,phandle = <0x10>;
+			phandle = <0x10>;
+		};
+
+		msgbox {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "msgbox";
+			linux,phandle = <0xe>;
+			phandle = <0xe>;
+		};
+
+		lvds {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "lvds";
+			linux,phandle = <0x6c>;
+			phandle = <0x6c>;
+		};
+
+		uart0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "uart0";
+			linux,phandle = <0x18>;
+			phandle = <0x18>;
+		};
+
+		uart1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "uart1";
+			linux,phandle = <0x1b>;
+			phandle = <0x1b>;
+		};
+
+		uart2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "uart2";
+			linux,phandle = <0x1e>;
+			phandle = <0x1e>;
+		};
+
+		uart3 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "uart3";
+			linux,phandle = <0x21>;
+			phandle = <0x21>;
+		};
+
+		uart4 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "uart4";
+			linux,phandle = <0x24>;
+			phandle = <0x24>;
+		};
+
+		scr {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "scr";
+			linux,phandle = <0x7d>;
+			phandle = <0x7d>;
+		};
+
+		twi0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "twi0";
+			linux,phandle = <0x27>;
+			phandle = <0x27>;
+		};
+
+		twi1 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "twi1";
+			linux,phandle = <0x2a>;
+			phandle = <0x2a>;
+		};
+
+		twi2 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "twi2";
+			linux,phandle = <0x2d>;
+			phandle = <0x2d>;
+		};
+
+		twi3 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "twi3";
+		};
+
+		pio {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-clock";
+			clock-output-names = "pio";
+			linux,phandle = <0xa>;
+			phandle = <0xa>;
+		};
+
+		cpurcir {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-cpus-clock";
+			clock-output-names = "cpurcir";
+			linux,phandle = <0x12>;
+			phandle = <0x12>;
+		};
+
+		cpurpio {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-cpus-clock";
+			clock-output-names = "cpurpio";
+			linux,phandle = <0x9>;
+			phandle = <0x9>;
+		};
+
+		cpurpll_peri0 {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-cpus-clock";
+			clock-output-names = "cpurpll_peri0";
+		};
+
+		cpurcpus {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-cpus-clock";
+			clock-output-names = "cpurcpus";
+		};
+
+		cpurahbs {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-cpus-clock";
+			clock-output-names = "cpurahbs";
+		};
+
+		cpurapbs {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-cpus-clock";
+			clock-output-names = "cpurapbs";
+		};
+
+		losc_out {
+			#clock-cells = <0x0>;
+			compatible = "allwinner,sunxi-periph-cpus-clock";
+			clock-output-names = "losc_out";
+			linux,phandle = <0x98>;
+			phandle = <0x98>;
+		};
+	};
+
+	soc@01c00000 {
+		compatible = "simple-bus";
+		#address-cells = <0x2>;
+		#size-cells = <0x2>;
+		ranges;
+		device_type = "soc";
+
+		pinctrl@01f02c00 {
+			compatible = "allwinner,sun50i-r-pinctrl";
+			reg = <0x0 0x1f02c00 0x0 0x400>;
+			interrupts = <0x0 0x2d 0x4>;
+			clocks = <0x9>;
+			device_type = "r_pio";
+			gpio-controller;
+			interrupt-controller;
+			#interrupt-cells = <0x2>;
+			#size-cells = <0x0>;
+			#gpio-cells = <0x6>;
+			linux,phandle = <0x79>;
+			phandle = <0x79>;
+
+			s_cir0@0 {
+				allwinner,pins = "PL11";
+				allwinner,function = "s_cir0";
+				allwinner,muxsel = <0x2>;
+				allwinner,drive = <0x2>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x11>;
+				phandle = <0x11>;
+			};
+
+			spwm0@0 {
+				linux,phandle = <0xaf>;
+				phandle = <0xaf>;
+				allwinner,pins = "PL10";
+				allwinner,function = "spwm0";
+				allwinner,pname = "pwm_positive";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x0>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			spwm0@1 {
+				linux,phandle = <0xb0>;
+				phandle = <0xb0>;
+				allwinner,pins = "PL10";
+				allwinner,function = "spwm0";
+				allwinner,pname = "pwm_positive";
+				allwinner,muxsel = <0x7>;
+				allwinner,pull = <0x0>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			s_uart0@0 {
+				linux,phandle = <0xb6>;
+				phandle = <0xb6>;
+				allwinner,pins = "PL2", "PL3";
+				allwinner,function = "s_uart0";
+				allwinner,pname = "s_uart0_tx", "s_uart0_rx";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			s_rsb0@0 {
+				linux,phandle = <0xb7>;
+				phandle = <0xb7>;
+				allwinner,pins = "PL0", "PL1";
+				allwinner,function = "s_rsb0";
+				allwinner,pname = "s_rsb0_sck", "s_rsb0_sda";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x2>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			s_jtag0@0 {
+				linux,phandle = <0xb8>;
+				phandle = <0xb8>;
+				allwinner,pins = "PL4", "PL5", "PL6", "PL7";
+				allwinner,function = "s_jtag0";
+				allwinner,pname = "s_jtag0_tms", "s_jtag0_tck", "s_jtag0_tdo", "s_jtag0_tdi";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x2>;
+				allwinner,data = <0xffffffff>;
+			};
+		};
+
+		pinctrl@01c20800 {
+			compatible = "allwinner,sun50i-pinctrl";
+			reg = <0x0 0x1c20800 0x0 0x400>;
+			interrupts = <0x0 0xb 0x4 0x0 0x11 0x4 0x0 0x15 0x4>;
+			device_type = "pio";
+			clocks = <0xa>;
+			gpio-controller;
+			interrupt-controller;
+			#interrupt-cells = <0x2>;
+			#size-cells = <0x0>;
+			#gpio-cells = <0x6>;
+			linux,phandle = <0x30>;
+			phandle = <0x30>;
+
+			uart0@1 {
+				allwinner,pins = "PB8", "PB9";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x1a>;
+				phandle = <0x1a>;
+			};
+
+			uart1@1 {
+				allwinner,pins = "PG6", "PG7", "PG8", "PG9";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x1d>;
+				phandle = <0x1d>;
+			};
+
+			uart2@1 {
+				allwinner,pins = "PB0", "PB1", "PB2", "PB3";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x20>;
+				phandle = <0x20>;
+			};
+
+			uart3@1 {
+				allwinner,pins = "PH4", "PH5", "PH6", "PH7";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x23>;
+				phandle = <0x23>;
+			};
+
+			uart4@1 {
+				allwinner,pins = "PD2", "PD3", "PD4", "PD5";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x26>;
+				phandle = <0x26>;
+			};
+
+			twi0@1 {
+				allwinner,pins = "PH0", "PH1";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x29>;
+				phandle = <0x29>;
+			};
+
+			twi1@1 {
+				allwinner,pins = "PH2", "PH3";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x2c>;
+				phandle = <0x2c>;
+			};
+
+			twi2@1 {
+				allwinner,pins = "PE14", "PE15";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x2f>;
+				phandle = <0x2f>;
+			};
+
+			spi0@2 {
+				allwinner,pins = "PC3", "PC2", "PC0", "PC1";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x55>;
+				phandle = <0x55>;
+			};
+
+			spi1@2 {
+				allwinner,pins = "PD0", "PD1", "PD2", "PD3";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x59>;
+				phandle = <0x59>;
+			};
+
+			sdc0@1 {
+				allwinner,pins = "PF0", "PF1", "PF2", "PF3", "PF4", "PF5";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x64>;
+				phandle = <0x64>;
+			};
+
+			sdc1@1 {
+				allwinner,pins = "PG0", "PG1", "PG2", "PG3", "PG4", "PG5";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x69>;
+				phandle = <0x69>;
+			};
+
+			sdc2@1 {
+				allwinner,pins = "PC1", "PC5", "PC6", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PC16";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x5f>;
+				phandle = <0x5f>;
+			};
+
+			daudio0@0 {
+				allwinner,pins = "PB6", "PB3", "PB4", "PB5", "PB7";
+				allwinner,function = "pcm0";
+				allwinner,muxsel = <0x3>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x43>;
+				phandle = <0x43>;
+			};
+
+			daudio0_sleep@0 {
+				allwinner,pins = "PB6", "PB3", "PB4", "PB5", "PB7";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x44>;
+				phandle = <0x44>;
+			};
+
+			daudio1@0 {
+				allwinner,pins = "PG10", "PG11", "PG12", "PG13";
+				allwinner,function = "pcm1";
+				allwinner,muxsel = <0x3>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x45>;
+				phandle = <0x45>;
+			};
+
+			daudio1_sleep@0 {
+				allwinner,pins = "PG10", "PG11", "PG12", "PG13";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x46>;
+				phandle = <0x46>;
+			};
+
+			aif3@0 {
+				allwinner,pins = "PG10", "PG11", "PG12", "PG13";
+				allwinner,function = "aif3";
+				allwinner,muxsel = <0x2>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x3e>;
+				phandle = <0x3e>;
+			};
+
+			aif2_sleep@0 {
+				allwinner,pins = "PB6", "PB4", "PB5", "PB7";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x3f>;
+				phandle = <0x3f>;
+			};
+
+			aif3_sleep@0 {
+				allwinner,pins = "PG10", "PG11", "PG12", "PG13";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x40>;
+				phandle = <0x40>;
+			};
+
+			spdif@0 {
+				allwinner,pins = "PH8";
+				allwinner,function = "spdif0";
+				allwinner,muxsel = <0x2>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x4a>;
+				phandle = <0x4a>;
+			};
+
+			spdif_sleep@0 {
+				allwinner,pins = "PH8";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x4b>;
+				phandle = <0x4b>;
+			};
+
+			csi0_sleep@0 {
+				allwinner,pins = "PE0", "PE2", "PE3", "PE4", "PE5", "PE6", "PE7", "PE8", "PE9", "PE10", "PE11", "PE12", "PE13";
+				allwinner,pname = "csi0_pck", "csi0_hsync", "csi0_vsync", "csi0_d0", "csi0_d1", "csi0_d2", "csi0_d3", "csi0_d4", "csi0_d5", "csi0_d6", "csi0_d7", "csi0_sck", "csi0_sda";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				allwinner,data = <0x0>;
+				linux,phandle = <0x77>;
+				phandle = <0x77>;
+			};
+
+			smartcard@0 {
+				allwinner,pins = "PB1", "PB4", "PB5", "PB6", "PB7";
+				allwinner,function = "sim0";
+				allwinner,muxsel = <0x5>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x1>;
+				linux,phandle = <0x7f>;
+				phandle = <0x7f>;
+			};
+
+			nand0@2 {
+				allwinner,pins = "PC0", "PC1", "PC2", "PC3", "PC4", "PC5", "PC6", "PC7", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PC16", "PC17", "PC18";
+				allwinner,function = "io_disabled";
+				allwinner,muxsel = <0x7>;
+				allwinner,drive = <0x1>;
+				allwinner,pull = <0x0>;
+				linux,phandle = <0x83>;
+				phandle = <0x83>;
+			};
+
+			card0_boot_para@0 {
+				linux,phandle = <0x99>;
+				phandle = <0x99>;
+				allwinner,pins = "PF0", "PF1", "PF2", "PF3", "PF4", "PF5";
+				allwinner,function = "card0_boot_para";
+				allwinner,pname = "sdc_d1", "sdc_d0", "sdc_clk", "sdc_cmd", "sdc_d3", "sdc_d2";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x2>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			card2_boot_para@0 {
+				linux,phandle = <0x9a>;
+				phandle = <0x9a>;
+				allwinner,pins = "PC1", "PC5", "PC6", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PC16";
+				allwinner,function = "card2_boot_para";
+				allwinner,pname = "sdc_ds", "sdc_clk", "sdc_cmd", "sdc_d0", "sdc_d1", "sdc_d2", "sdc_d3", "sdc_d4", "sdc_d5", "sdc_d6", "sdc_d7", "sdc_emmc_rst";
+				allwinner,muxsel = <0x3>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x3>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			twi_para@0 {
+				linux,phandle = <0x9b>;
+				phandle = <0x9b>;
+				allwinner,pins = "PH0", "PH1";
+				allwinner,function = "twi_para";
+				allwinner,pname = "twi_scl", "twi_sda";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			uart_para@0 {
+				linux,phandle = <0x9c>;
+				phandle = <0x9c>;
+				allwinner,pins = "PB8", "PB9";
+				allwinner,function = "uart_para";
+				allwinner,pname = "uart_debug_tx", "uart_debug_rx";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			jtag_para@0 {
+				linux,phandle = <0x9d>;
+				phandle = <0x9d>;
+				allwinner,pins = "PB0", "PB1", "PB2", "PB3";
+				allwinner,function = "jtag_para";
+				allwinner,pname = "jtag_ms", "jtag_ck", "jtag_do", "jtag_di";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			gmac0@0 {
+				linux,phandle = <0x9e>;
+				phandle = <0x9e>;
+				allwinner,pins = "PD18", "PD17", "PD16", "PD15", "PD20", "PD19", "PD11", "PD10", "PD9", "PD8", "PD13", "PD12", "PD21", "PD22", "PD23";
+				allwinner,function = "gmac0";
+				allwinner,pname = "gmac_txd0", "gmac_txd1", "gmac_txd2", "gmac_txd3", "gmac_txen", "gmac_gtxclk", "gmac_rxd0", "gmac_rxd1", "gmac_rxd2", "gmac_rxd3", "gmac_rxdv", "gmac_rxclk", "gmac_clkin", "gmac_mdc", "gmac_mdio";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			twi0@0 {
+				linux,phandle = <0x9f>;
+				phandle = <0x9f>;
+				allwinner,pins = "PH0", "PH1";
+				allwinner,function = "twi0";
+				allwinner,pname = "twi0_scl", "twi0_sda";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			twi1@0 {
+				linux,phandle = <0xa0>;
+				phandle = <0xa0>;
+				allwinner,pins = "PH2", "PH3";
+				allwinner,function = "twi1";
+				allwinner,pname = "twi1_scl", "twi1_sda";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			twi2@0 {
+				linux,phandle = <0xa1>;
+				phandle = <0xa1>;
+				allwinner,pins = "PE14", "PE15";
+				allwinner,function = "twi2";
+				allwinner,pname = "twi2_scl", "twi2_sda";
+				allwinner,muxsel = <0x3>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			uart0@0 {
+				linux,phandle = <0xa2>;
+				phandle = <0xa2>;
+				allwinner,pins = "PB8", "PB9";
+				allwinner,function = "uart0";
+				allwinner,pname = "uart0_tx", "uart0_rx";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			uart1@0 {
+				linux,phandle = <0xa3>;
+				phandle = <0xa3>;
+				allwinner,pins = "PG6", "PG7", "PG8", "PG9";
+				allwinner,function = "uart1";
+				allwinner,pname = "uart1_tx", "uart1_rx", "uart1_rts", "uart1_cts";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			uart2@0 {
+				linux,phandle = <0xa4>;
+				phandle = <0xa4>;
+				allwinner,pins = "PB0", "PB1", "PB2", "PB3";
+				allwinner,function = "uart2";
+				allwinner,pname = "uart2_tx", "uart2_rx", "uart2_rts", "uart2_cts";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			uart3@0 {
+				linux,phandle = <0xa5>;
+				phandle = <0xa5>;
+				allwinner,pins = "PD0", "PD1";
+				allwinner,function = "uart3";
+				allwinner,pname = "uart3_tx", "uart3_rx";
+				allwinner,muxsel = <0x3>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			uart4@0 {
+				linux,phandle = <0xa6>;
+				phandle = <0xa6>;
+				allwinner,pins = "PD2", "PD3", "PD4", "PD5";
+				allwinner,function = "uart4";
+				allwinner,pname = "uart4_tx", "uart4_rx", "uart4_rts", "uart4_cts";
+				allwinner,muxsel = <0x3>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			spi0@0 {
+				linux,phandle = <0xa7>;
+				phandle = <0xa7>;
+				allwinner,pins = "PC3";
+				allwinner,function = "spi0";
+				allwinner,pname = "spi0_cs0";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			spi0@1 {
+				linux,phandle = <0xa8>;
+				phandle = <0xa8>;
+				allwinner,pins = "PC2", "PC0", "PC1";
+				allwinner,function = "spi0";
+				allwinner,pname = "spi0_sclk", "spi0_mosi", "spi0_miso";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			spi1@0 {
+				linux,phandle = <0xa9>;
+				phandle = <0xa9>;
+				allwinner,pins = "PD0";
+				allwinner,function = "spi1";
+				allwinner,pname = "spi1_cs0";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			spi1@1 {
+				linux,phandle = <0xaa>;
+				phandle = <0xaa>;
+				allwinner,pins = "PD1", "PD2", "PD3";
+				allwinner,function = "spi1";
+				allwinner,pname = "spi1_sclk", "spi1_mosi", "spi1_miso";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			nand0@0 {
+				linux,phandle = <0xab>;
+				phandle = <0xab>;
+				allwinner,pins = "PC0", "PC1", "PC2", "PC5", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PC16";
+				allwinner,function = "nand0";
+				allwinner,pname = "nand0_we", "nand0_ale", "nand0_cle", "nand0_nre", "nand0_d0", "nand0_d1", "nand0_d2", "nand0_d3", "nand0_d4", "nand0_d5", "nand0_d6", "nand0_d7", "nand0_ndqs";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x0>;
+				allwinner,drive = <0x1>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			nand0@1 {
+				linux,phandle = <0xac>;
+				phandle = <0xac>;
+				allwinner,pins = "PC3", "PC4", "PC6", "PC7", "PC17", "PC18";
+				allwinner,function = "nand0";
+				allwinner,pname = "nand0_ce1", "nand0_ce0", "nand0_rb0", "nand0_rb1", "nand0_ce2", "nand0_ce3";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x1>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			pwm0@0 {
+				linux,phandle = <0xad>;
+				phandle = <0xad>;
+				allwinner,pins = "PD22";
+				allwinner,function = "pwm0";
+				allwinner,pname = "pwm_positive";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x0>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			pwm0@1 {
+				linux,phandle = <0xae>;
+				phandle = <0xae>;
+				allwinner,pins = "PD22";
+				allwinner,function = "pwm0";
+				allwinner,pname = "pwm_positive";
+				allwinner,muxsel = <0x7>;
+				allwinner,pull = <0x0>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			csi0@0 {
+				linux,phandle = <0xb1>;
+				phandle = <0xb1>;
+				allwinner,pins = "PE0", "PE2", "PE3", "PE4", "PE5", "PE6", "PE7", "PE8", "PE9", "PE10", "PE11", "PE12", "PE13";
+				allwinner,function = "csi0";
+				allwinner,pname = "csi0_pck", "csi0_hsync", "csi0_vsync", "csi0_d0", "csi0_d1", "csi0_d2", "csi0_d3", "csi0_d4", "csi0_d5", "csi0_d6", "csi0_d7", "csi0_sck", "csi0_sda";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0xffffffff>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			sdc0@0 {
+				linux,phandle = <0xb2>;
+				phandle = <0xb2>;
+				allwinner,pins = "PF0", "PF1", "PF2", "PF3", "PF4", "PF5";
+				allwinner,function = "sdc0";
+				allwinner,pname = "sdc0_d1", "sdc0_d0", "sdc0_clk", "sdc0_cmd", "sdc0_d3", "sdc0_d2";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x2>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			sdc1@0 {
+				linux,phandle = <0xb3>;
+				phandle = <0xb3>;
+				allwinner,pins = "PG0", "PG1", "PG2", "PG3", "PG4", "PG5";
+				allwinner,function = "sdc1";
+				allwinner,pname = "sdc1_clk", "sdc1_cmd", "sdc1_d0", "sdc1_d1", "sdc1_d2", "sdc1_d3";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x3>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			sdc2@0 {
+				linux,phandle = <0xb4>;
+				phandle = <0xb4>;
+				allwinner,pins = "PC1", "PC5", "PC6", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PC16";
+				allwinner,function = "sdc2";
+				allwinner,pname = "sdc2_ds", "sdc2_clk", "sdc2_cmd", "sdc2_d0", "sdc2_d1", "sdc2_d2", "sdc2_d3", "sdc2_d4", "sdc2_d5", "sdc2_d6", "sdc2_d7", "sdc2_emmc_rst";
+				allwinner,muxsel = <0x3>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x3>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			codec@0 {
+				linux,phandle = <0xb5>;
+				phandle = <0xb5>;
+				allwinner,pins = "PH7";
+				allwinner,function = "codec";
+				allwinner,pname = "gpio-spk";
+				allwinner,muxsel = <0x2>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0xffffffff>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			Vdevice@0 {
+				linux,phandle = <0xb9>;
+				phandle = <0xb9>;
+				allwinner,pins = "PB1", "PB2";
+				allwinner,function = "Vdevice";
+				allwinner,pname = "Vdevice_0", "Vdevice_1";
+				allwinner,muxsel = <0x4>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x2>;
+				allwinner,data = <0xffffffff>;
+			};
+
+			w1_pin@0 {
+				linux,phandle = <0xba>;
+				phandle = <0xba>;
+				allwinner,pins = "PC8";
+				allwinner,function = "gpio_in";
+				allwinner,pname = "w1";
+				allwinner,muxsel = <0x0>;
+				allwinner,pull = <0x1>;
+				allwinner,drive = <0x0>;
+				allwinner,data = <0xffffffff>;
+			};
+		};
+
+		pinctrl@0 {
+			compatible = "allwinner,axp-pinctrl";
+			gpio-controller;
+			#size-cells = <0x0>;
+			#gpio-cells = <0x6>;
+			device_type = "axp_pio";
+			linux,phandle = <0x31>;
+			phandle = <0x31>;
+		};
+
+		dma-controller@01c02000 {
+			compatible = "allwinner,sun50i-dma";
+			reg = <0x0 0x1c02000 0x0 0x1000>;
+			interrupts = <0x0 0x32 0x4>;
+			clocks = <0xb>;
+			#dma-cells = <0x1>;
+		};
+
+		mbus-controller@01c62000 {
+			compatible = "allwinner,sun50i-mbus";
+			reg = <0x0 0x1c62000 0x0 0x110>;
+			#mbus-cells = <0x1>;
+		};
+
+		arisc {
+			compatible = "allwinner,sunxi-arisc";
+			#address-cells = <0x2>;
+			#size-cells = <0x2>;
+			clocks = <0xc 0xd 0x6 0x4>;
+			clock-names = "losc", "iosc", "hosc", "pll_periph0";
+			powchk_used = <0x0>;
+			power_reg = <0x2309621>;
+			system_power = <0x32>;
+		};
+
+		arisc_space {
+			compatible = "allwinner,arisc_space";
+			space1 = <0x40000 0x0 0x14000>;
+			space2 = <0x40100000 0x18000 0x4000>;
+			space3 = <0x40104000 0x0 0x1000>;
+			space4 = <0x40105000 0x0 0x1000>;
+		};
+
+		standby_space {
+			compatible = "allwinner,standby_space";
+			space1 = <0x41020000 0x0 0x800>;
+		};
+
+		msgbox@1c17000 {
+			compatible = "allwinner,msgbox";
+			clocks = <0xe>;
+			clock-names = "clk_msgbox";
+			reg = <0x0 0x1c17000 0x0 0x1000>;
+			interrupts = <0x0 0x31 0x1>;
+			status = "okay";
+		};
+
+		hwspinlock@1c18000 {
+			compatible = "allwinner,sunxi-hwspinlock";
+			clocks = <0xf 0x10>;
+			clock-names = "clk_hwspinlock_rst", "clk_hwspinlock_bus";
+			reg = <0x0 0x1c18000 0x0 0x1000>;
+			status = "okay";
+			num-locks = <0x8>;
+		};
+
+		s_cir@1f02000 {
+			compatible = "allwinner,s_cir";
+			reg = <0x0 0x1f02000 0x0 0x400>;
+			interrupts = <0x0 0x25 0x4>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x11>;
+			clocks = <0x6 0x12>;
+			supply = "vcc-pl";
+			ir_power_key_code = <0x4d>;
+			ir_addr_code = <0x4040>;
+			status = "okay";
+			device_type = "s_cir0";
+		};
+
+		s_uart@1f02800 {
+			compatible = "allwinner,s_uart";
+			reg = <0x0 0x1f02800 0x0 0x400>;
+			interrupts = <0x0 0x26 0x4>;
+			pinctrl-names = "default";
+			status = "okay";
+			device_type = "s_uart0";
+			pinctrl-0 = <0xb6>;
+		};
+
+		s_rsb@1f03400 {
+			compatible = "allwinner,s_rsb";
+			reg = <0x0 0x1f03400 0x0 0x400>;
+			interrupts = <0x0 0x27 0x4>;
+			pinctrl-names = "default";
+			status = "okay";
+			device_type = "s_rsb0";
+			pinctrl-0 = <0xb7>;
+		};
+
+		s_jtag0 {
+			compatible = "allwinner,s_jtag";
+			pinctrl-names = "default";
+			status = "disabled";
+			device_type = "s_jtag0";
+			pinctrl-0 = <0xb8>;
+		};
+
+		timer@1c20c00 {
+			compatible = "allwinner,sunxi-timer";
+			device_type = "timer";
+			reg = <0x0 0x1c20c00 0x0 0x90>;
+			interrupts = <0x0 0x12 0x1>;
+			clock-frequency = <0x16e3600>;
+			timer-prescale = <0x10>;
+		};
+
+		rtc@01f00000 {
+			compatible = "allwinner,sun50i-rtc";
+			device_type = "rtc";
+			reg = <0x0 0x1f00000 0x0 0x218>;
+			interrupts = <0x0 0x28 0x4>;
+			gpr_offset = <0x100>;
+			gpr_len = <0x4>;
+		};
+
+		ve@01c0e000 {
+			compatible = "allwinner,sunxi-cedar-ve";
+			reg = <0x0 0x1c0e000 0x0 0x1000 0x0 0x1c00000 0x0 0x10 0x0 0x1c20000 0x0 0x800>;
+			interrupts = <0x0 0x3a 0x4>;
+			clocks = <0x16 0x17>;
+		};
+
+		uart@01c28000 {
+			compatible = "allwinner,sun50i-uart";
+			device_type = "uart0";
+			reg = <0x0 0x1c28000 0x0 0x400>;
+			interrupts = <0x0 0x0 0x4>;
+			clocks = <0x18>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x1a>;
+			uart0_port = <0x0>;
+			uart0_type = <0x2>;
+			status = "okay";
+			pinctrl-0 = <0xa2>;
+		};
+
+		uart@01c28400 {
+			compatible = "allwinner,sun50i-uart";
+			device_type = "uart1";
+			reg = <0x0 0x1c28400 0x0 0x400>;
+			interrupts = <0x0 0x1 0x4>;
+			clocks = <0x1b>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x1d>;
+			uart1_port = <0x1>;
+			uart1_type = <0x4>;
+			status = "okay";
+			pinctrl-0 = <0xa3>;
+		};
+
+		uart@01c28800 {
+			compatible = "allwinner,sun50i-uart";
+			device_type = "uart2";
+			reg = <0x0 0x1c28800 0x0 0x400>;
+			interrupts = <0x0 0x2 0x4>;
+			clocks = <0x1e>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x20>;
+			uart2_port = <0x2>;
+			uart2_type = <0x4>;
+			status = "okay";
+			pinctrl-0 = <0xa4>;
+		};
+
+		uart@01c28c00 {
+			compatible = "allwinner,sun50i-uart";
+			device_type = "uart3";
+			reg = <0x0 0x1c28c00 0x0 0x400>;
+			interrupts = <0x0 0x3 0x4>;
+			clocks = <0x21>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x23>;
+			uart3_port = <0x3>;
+			uart3_type = <0x4>;
+			status = "okay";
+			pinctrl-0 = <0xa5>;
+		};
+
+		uart@01c29000 {
+			compatible = "allwinner,sun50i-uart";
+			device_type = "uart4";
+			reg = <0x0 0x1c29000 0x0 0x400>;
+			interrupts = <0x0 0x4 0x4>;
+			clocks = <0x24>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x26>;
+			uart4_port = <0x4>;
+			uart4_type = <0x4>;
+			status = "okay";
+			pinctrl-0 = <0xa6>;
+		};
+
+		twi@0x01c2ac00 {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			compatible = "allwinner,sun50i-twi";
+			device_type = "twi0";
+			reg = <0x0 0x1c2ac00 0x0 0x400>;
+			interrupts = <0x0 0x6 0x4>;
+			clocks = <0x27>;
+			clock-frequency = <0x61a80>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x29>;
+			status = "okay";
+			pinctrl-0 = <0x9f>;
+		};
+
+		twi@0x01c2b000 {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			compatible = "allwinner,sun50i-twi";
+			device_type = "twi1";
+			reg = <0x0 0x1c2b000 0x0 0x400>;
+			interrupts = <0x0 0x7 0x4>;
+			clocks = <0x2a>;
+			clock-frequency = <0x30d40>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x2c>;
+			status = "okay";
+			pinctrl-0 = <0xa0>;
+		};
+
+		twi@0x01c2b400 {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			compatible = "allwinner,sun50i-twi";
+			device_type = "twi2";
+			reg = <0x0 0x1c2b400 0x0 0x400>;
+			interrupts = <0x0 0x8 0x4>;
+			clocks = <0x2d>;
+			clock-frequency = <0x30d40>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x2f>;
+			status = "disabled";
+			pinctrl-0 = <0xa1>;
+		};
+
+		usbc0@0 {
+			device_type = "usbc0";
+			compatible = "allwinner,sunxi-otg-manager";
+			usb_port_type = <0x1>;
+			usb_detect_type = <0x0>;
+			usb_host_init_state = <0x1>;
+			usb_regulator_io = "nocare";
+			usb_wakeup_suspend = <0x1>;
+			usb_luns = <0x3>;
+			usb_serial_unique = <0x1>;
+			usb_serial_number = "20080411";
+			rndis_wceis = <0x1>;
+			status = "okay";
+			usb_id_gpio;
+			usb_det_vbus_gpio;
+			usb_drv_vbus_gpio;
+		};
+
+		udc-controller@0x01c19000 {
+			compatible = "allwinner,sunxi-udc";
+			reg = <0x0 0x1c19000 0x0 0x1000 0x0 0x1c00000 0x0 0x100>;
+			interrupts = <0x0 0x47 0x4>;
+			clocks = <0x32 0x33>;
+			status = "okay";
+		};
+
+		ehci0-controller@0x01c1a000 {
+			compatible = "allwinner,sunxi-ehci0";
+			reg = <0x0 0x1c1a000 0x0 0xfff 0x0 0x1c00000 0x0 0x100 0x0 0x1c19000 0x0 0x1000>;
+			interrupts = <0x0 0x48 0x4>;
+			clocks = <0x32 0x34>;
+			hci_ctrl_no = <0x0>;
+			status = "okay";
+		};
+
+		ohci0-controller@0x01c1a400 {
+			compatible = "allwinner,sunxi-ohci0";
+			reg = <0x0 0x1c1a000 0x0 0xfff 0x0 0x1c00000 0x0 0x100 0x0 0x1c19000 0x0 0x1000>;
+			interrupts = <0x0 0x49 0x4>;
+			clocks = <0x32 0x35>;
+			hci_ctrl_no = <0x0>;
+			status = "okay";
+		};
+
+		usbc1@0 {
+			device_type = "usbc1";
+			usb_host_init_state = <0x1>;
+			usb_regulator_io = "nocare";
+			usb_wakeup_suspend = <0x1>;
+			usb_hsic_used = <0x0>;
+			usb_hsic_regulator_io = "vcc-hsic-12";
+			usb_hsic_ctrl = <0x0>;
+			usb_hsic_usb3503_flag = <0x0>;
+			status = "okay";
+			usb_port_type = <0x1>;
+			usb_detect_type = <0x0>;
+			usb_drv_vbus_gpio;
+			usb_hsic_rdy_gpio;
+			usb_hsic_hub_connect_gpio;
+			usb_hsic_int_n_gpio;
+			usb_hsic_reset_n_gpio;
+		};
+
+		ehci1-controller@0x01c1b000 {
+			compatible = "allwinner,sunxi-ehci1";
+			reg = <0x0 0x1c1b000 0x0 0xfff 0x0 0x1c00000 0x0 0x100 0x0 0x1c19000 0x0 0x1000>;
+			interrupts = <0x0 0x4a 0x4>;
+			clocks = <0x36 0x37 0x38 0x39 0x3a>;
+			hci_ctrl_no = <0x1>;
+			status = "okay";
+		};
+
+		ohci1-controller@0x01c1b400 {
+			compatible = "allwinner,sunxi-ohci1";
+			reg = <0x0 0x1c1b000 0x0 0xfff 0x0 0x1c00000 0x0 0x100 0x0 0x1c19000 0x0 0x1000>;
+			interrupts = <0x0 0x4b 0x4>;
+			clocks = <0x36 0x3b>;
+			hci_ctrl_no = <0x1>;
+			status = "okay";
+		};
+
+		codec@0x01c22c00 {
+			compatible = "allwinner,sunxi-internal-codec";
+			reg = <0x0 0x1c22c00 0x0 0x478 0x0 0x1f015c0 0x0 0x0>;
+			clocks = <0x3c>;
+			pinctrl-names = "aif2-default", "aif3-default", "aif2-sleep", "aif3-sleep";
+			pinctrl-1 = <0x3e>;
+			pinctrl-2 = <0x3f>;
+			pinctrl-3 = <0x40>;
+			gpio-spk = <0x30 0x7 0x7 0x1 0x1 0x1 0x1>;
+			headphonevol = <0x3b>;
+			spkervol = <0x1a>;
+			earpiecevol = <0x1e>;
+			maingain = <0x4>;
+			headsetmicgain = <0x4>;
+			adcagc_cfg = <0x0>;
+			adcdrc_cfg = <0x0>;
+			adchpf_cfg = <0x0>;
+			dacdrc_cfg = <0x0>;
+			dachpf_cfg = <0x0>;
+			aif1_lrlk_div = <0x40>;
+			aif2_lrlk_div = <0x40>;
+			aif2config = <0x0>;
+			aif3config = <0x0>;
+			pa_sleep_time = <0x15e>;
+			dac_digital_vol = <0xa0a0>;
+			status = "okay";
+			linux,phandle = <0x4d>;
+			phandle = <0x4d>;
+			device_type = "codec";
+			pinctrl-0 = <0xb5>;
+		};
+
+		i2s0-controller@0x01c22c00 {
+			compatible = "allwinner,sunxi-internal-i2s";
+			reg = <0x0 0x1c22c00 0x0 0x478>;
+			clocks = <0x2 0x41>;
+			status = "okay";
+			linux,phandle = <0x4c>;
+			phandle = <0x4c>;
+			device_type = "i2s";
+		};
+
+		daudio@0x01c22000 {
+			compatible = "allwinner,sunxi-daudio";
+			reg = <0x0 0x1c22000 0x0 0x58>;
+			clocks = <0x2 0x42>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-0 = <0x43>;
+			pinctrl-1 = <0x44>;
+			pcm_lrck_period = <0x20>;
+			pcm_lrckr_period = <0x1>;
+			slot_width_select = <0x20>;
+			pcm_lsb_first = <0x0>;
+			tx_data_mode = <0x0>;
+			rx_data_mode = <0x0>;
+			daudio_master = <0x4>;
+			audio_format = <0x1>;
+			signal_inversion = <0x1>;
+			frametype = <0x0>;
+			tdm_config = <0x1>;
+			tdm_num = <0x0>;
+			status = "disabled";
+			linux,phandle = <0x4e>;
+			phandle = <0x4e>;
+			device_type = "daudio0";
+		};
+
+		daudio@0x01c22400 {
+			compatible = "allwinner,sunxi-daudio";
+			reg = <0x0 0x1c22400 0x0 0x58>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-0 = <0x45>;
+			pinctrl-1 = <0x46>;
+			clocks = <0x2 0x47>;
+			pcm_lrck_period = <0x20>;
+			pcm_lrckr_period = <0x1>;
+			slot_width_select = <0x20>;
+			pcm_lsb_first = <0x0>;
+			tx_data_mode = <0x0>;
+			rx_data_mode = <0x0>;
+			daudio_master = <0x4>;
+			audio_format = <0x1>;
+			signal_inversion = <0x1>;
+			frametype = <0x0>;
+			tdm_config = <0x1>;
+			tdm_num = <0x1>;
+			status = "disabled";
+			linux,phandle = <0x4f>;
+			phandle = <0x4f>;
+			device_type = "daudio1";
+		};
+
+		daudio@0x01c22800 {
+			compatible = "allwinner,sunxi-tdmhdmi";
+			reg = <0x0 0x1c22800 0x0 0x58>;
+			clocks = <0x2 0x48>;
+			status = "okay";
+			linux,phandle = <0x50>;
+			phandle = <0x50>;
+			device_type = "daudio2";
+		};
+
+		spdif-controller@0x01c21000 {
+			compatible = "allwinner,sunxi-spdif";
+			reg = <0x0 0x1c21000 0x0 0x38>;
+			clocks = <0x2 0x49>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-0 = <0x4a>;
+			pinctrl-1 = <0x4b>;
+			status = "disabled";
+			linux,phandle = <0x51>;
+			phandle = <0x51>;
+			device_type = "spdif";
+		};
+
+		sound@0 {
+			compatible = "allwinner,sunxi-codec-machine";
+			interrupts = <0x0 0x1c 0x4>;
+			sunxi,i2s-controller = <0x4c>;
+			sunxi,audio-codec = <0x4d>;
+			aif2fmt = <0x3>;
+			aif3fmt = <0x3>;
+			aif2master = <0x1>;
+			hp_detect_case = <0x1>;
+			status = "okay";
+			device_type = "sndcodec";
+		};
+
+		sound@1 {
+			compatible = "allwinner,sunxi-daudio0-machine";
+			sunxi,daudio0-controller = <0x4e>;
+			status = "disabled";
+			device_type = "snddaudio0";
+		};
+
+		sound@2 {
+			compatible = "allwinner,sunxi-daudio1-machine";
+			sunxi,daudio1-controller = <0x4f>;
+			status = "disabled";
+			device_type = "snddaudio1";
+		};
+
+		sound@3 {
+			compatible = "allwinner,sunxi-hdmi-machine";
+			sunxi,hdmi-controller = <0x50>;
+			status = "okay";
+			device_type = "sndhdmi";
+		};
+
+		sound@4 {
+			compatible = "allwinner,sunxi-spdif-machine";
+			sunxi,spdif-controller = <0x51>;
+			status = "disabled";
+			device_type = "sndspdif";
+		};
+
+		spi@01c68000 {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			compatible = "allwinner,sun50i-spi";
+			device_type = "spi0";
+			reg = <0x0 0x1c68000 0x0 0x1000>;
+			interrupts = <0x0 0x41 0x4>;
+			clocks = <0x4 0x52>;
+			clock-frequency = <0x5f5e100>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x55>;
+			spi0_cs_number = <0x1>;
+			spi0_cs_bitmap = <0x1>;
+			status = "disabled";
+			pinctrl-0 = <0xa7 0xa8>;
+		};
+
+		spi@01c69000 {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			compatible = "allwinner,sun50i-spi";
+			device_type = "spi1";
+			reg = <0x0 0x1c69000 0x0 0x1000>;
+			interrupts = <0x0 0x42 0x4>;
+			clocks = <0x4 0x56>;
+			clock-frequency = <0x5f5e100>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x59>;
+			spi1_cs_number = <0x1>;
+			spi1_cs_bitmap = <0x1>;
+			status = "disabled";
+			pinctrl-0 = <0xa9 0xaa>;
+		};
+
+		sdmmc@01C11000 {
+			compatible = "allwinner,sun50i-sdmmc2";
+			device_type = "sdc2";
+			reg = <0x0 0x1c11000 0x0 0x1000>;
+			interrupts = <0x0 0x3e 0x104>;
+			clocks = <0x6 0x5a 0x5b 0x5c 0x5d>;
+			clock-names = "osc24m", "pll_periph", "mmc", "ahb", "rst";
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x5f>;
+			bus-width = <0x8>;
+			max-frequency = <0x5f5e100>;
+			sdc_tm4_sm0_freq0 = <0x0>;
+			sdc_tm4_sm0_freq1 = <0x0>;
+			sdc_tm4_sm1_freq0 = <0x0>;
+			sdc_tm4_sm1_freq1 = <0x0>;
+			sdc_tm4_sm2_freq0 = <0x0>;
+			sdc_tm4_sm2_freq1 = <0x0>;
+			sdc_tm4_sm3_freq0 = <0x5000000>;
+			sdc_tm4_sm3_freq1 = <0x405>;
+			sdc_tm4_sm4_freq0 = <0x50000>;
+			sdc_tm4_sm4_freq1 = <0x408>;
+			status = "disabled";
+			non-removable;
+			pinctrl-0 = <0xb4>;
+			cd-gpios;
+			sunxi-power-save-mode;
+			sunxi-dis-signal-vol-sw;
+			mmc-ddr-1_8v;
+			mmc-hs200-1_8v;
+			mmc-hs400-1_8v;
+			vmmc = "vcc-emmc";
+			vqmmc = "vcc-lpddr";
+			vdmmc = "none";
+		};
+
+		sdmmc@01c0f000 {
+			compatible = "allwinner,sun50i-sdmmc0";
+			device_type = "sdc0";
+			reg = <0x0 0x1c0f000 0x0 0x1000>;
+			interrupts = <0x0 0x3c 0x104>;
+			clocks = <0x6 0x5a 0x60 0x61 0x62>;
+			clock-names = "osc24m", "pll_periph", "mmc", "ahb", "rst";
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x64>;
+			max-frequency = <0x2faf080>;
+			bus-width = <0x4>;
+			broken-cd;
+			status = "okay";
+			pinctrl-0 = <0xb2>;
+			cd-gpios = <0x30 0x5 0x6 0x0 0x1 0x2 0xffffffff>;
+			sunxi-power-save-mode;
+			vmmc = "none";
+			vqmmc = "none";
+			vdmmc = "vcc-sdc";
+		};
+
+		sdmmc@1C10000 {
+			compatible = "allwinner,sun50i-sdmmc1";
+			device_type = "sdc1";
+			reg = <0x0 0x1c10000 0x0 0x1000>;
+			interrupts = <0x0 0x3d 0x104>;
+			clocks = <0x6 0x5a 0x65 0x66 0x67>;
+			clock-names = "osc24m", "pll_periph", "mmc", "ahb", "rst";
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x69>;
+			max-frequency = <0x8f0d180>;
+			bus-width = <0x4>;
+			sunxi-dly-52M-ddr4 = <0x1 0x0 0x0 0x0 0x2>;
+			sunxi-dly-104M = <0x1 0x0 0x0 0x0 0x1>;
+			sunxi-dly-208M = <0x1 0x0 0x0 0x0 0x1>;
+			status = "okay";
+			pinctrl-0 = <0xb3>;
+			sd-uhs-sdr50;
+			sd-uhs-ddr50;
+			sd-uhs-sdr104;
+			cap-sdio-irq;
+			keep-power-in-suspend;
+			ignore-pm-notify;
+		};
+
+		disp@01000000 {
+			compatible = "allwinner,sun50i-disp";
+			reg = <0x0 0x1000000 0x0 0x300000 0x0 0x1c0c000 0x0 0x17fc 0x0 0x1ca0000 0x0 0x10fc>;
+			interrupts = <0x0 0x56 0x104 0x0 0x57 0x104 0x0 0x59 0x104>;
+			clocks = <0x6a 0x6b 0x6c 0x6d 0x6e>;
+			status = "okay";
+			device_type = "disp";
+			disp_init_enable = <0x1>;
+			disp_mode = <0x0>;
+			screen0_output_type = <0x1>;
+			screen0_output_mode = <0x4>;
+			screen1_output_type = <0x3>;
+			screen1_output_mode = <0xa>;
+			fb0_format = <0x0>;
+			fb0_width = <0x0>;
+			fb0_height = <0x0>;
+			fb1_format = <0x0>;
+			fb1_width = <0x0>;
+			fb1_height = <0x0>;
+		};
+
+		lcd0@01c0c000 {
+			compatible = "allwinner,sunxi-lcd0";
+			pinctrl-names = "active", "sleep";
+			status = "okay";
+			device_type = "lcd0";
+			lcd_used = <0x1>;
+			lcd_driver_name = "mb709_mipi";
+			lcd_backlight = <0x32>;
+			lcd_if = <0x4>;
+			lcd_x = <0x400>;
+			lcd_y = <0x258>;
+			lcd_width = <0x400>;
+			lcd_height = <0x258>;
+			lcd_dclk_freq = <0x37>;
+			lcd_pwm_used = <0x1>;
+			lcd_pwm_ch = <0x10>;
+			lcd_pwm_freq = <0xc350>;
+			lcd_pwm_pol = <0x1>;
+			lcd_pwm_max_limit = <0xfa>;
+			lcd_hbp = <0x78>;
+			lcd_ht = <0x604>;
+			lcd_hspw = <0x14>;
+			lcd_vbp = <0x17>;
+			lcd_vt = <0x27b>;
+			lcd_vspw = <0x2>;
+			lcd_dsi_if = <0x2>;
+			lcd_dsi_lane = <0x4>;
+			lcd_dsi_format = <0x0>;
+			lcd_dsi_eotp = <0x0>;
+			lcd_dsi_vc = <0x0>;
+			lcd_dsi_te = <0x0>;
+			lcd_frm = <0x0>;
+			lcd_gamma_en = <0x0>;
+			lcd_bright_curve_en = <0x0>;
+			lcd_cmap_en = <0x0>;
+			lcd_bl_en = <0x30 0x7 0xa 0x1 0x0 0xffffffff 0x1>;
+			lcd_bl_en_power = "none";
+			lcd_power = "vcc-mipi";
+			lcd_fix_power = "vcc-dsi-33";
+			lcd_gpio_0 = <0x30 0x3 0x18 0x1 0x0 0xffffffff 0x1>;
+		};
+
+		hdmi@01ee0000 {
+			compatible = "allwinner,sunxi-hdmi";
+			reg = <0x0 0x1ee0000 0x0 0x20000>;
+			clocks = <0x6f 0x70>;
+			device_type = "hdmi";
+			status = "okay";
+			hdmi_power = "vcc-hdmi-33";
+			hdmi_hdcp_enable = <0x0>;
+			hdmi_cts_compatibility = <0x0>;
+		};
+
+		tr@01000000 {
+			compatible = "allwinner,sun50i-tr";
+			reg = <0x0 0x1000000 0x0 0x200bc>;
+			interrupts = <0x0 0x60 0x104>;
+			clocks = <0x6a>;
+			status = "okay";
+		};
+
+		pwm@01c21400 {
+			compatible = "allwinner,sunxi-pwm";
+			reg = <0x0 0x1c21400 0x0 0x3c>;
+			pwm-number = <0x1>;
+			pwm-base = <0x0>;
+			pwms = <0x71>;
+		};
+
+		pwm0@01c21400 {
+			compatible = "allwinner,sunxi-pwm0";
+			pinctrl-names = "active", "sleep";
+			reg_base = <0x1c21400>;
+			reg_busy_offset = <0x0>;
+			reg_busy_shift = <0x1c>;
+			reg_enable_offset = <0x0>;
+			reg_enable_shift = <0x4>;
+			reg_clk_gating_offset = <0x0>;
+			reg_clk_gating_shift = <0x6>;
+			reg_bypass_offset = <0x0>;
+			reg_bypass_shift = <0x9>;
+			reg_pulse_start_offset = <0x0>;
+			reg_pulse_start_shift = <0x8>;
+			reg_mode_offset = <0x0>;
+			reg_mode_shift = <0x7>;
+			reg_polarity_offset = <0x0>;
+			reg_polarity_shift = <0x5>;
+			reg_period_offset = <0x4>;
+			reg_period_shift = <0x10>;
+			reg_period_width = <0x10>;
+			reg_active_offset = <0x4>;
+			reg_active_shift = <0x0>;
+			reg_active_width = <0x10>;
+			reg_prescal_offset = <0x0>;
+			reg_prescal_shift = <0x0>;
+			reg_prescal_width = <0x4>;
+			linux,phandle = <0x71>;
+			phandle = <0x71>;
+			device_type = "pwm0";
+			pwm_used = <0x0>;
+			pinctrl-0 = <0xad>;
+			pinctrl-1 = <0xae>;
+		};
+
+		s_pwm@1f03800 {
+			compatible = "allwinner,sunxi-s_pwm";
+			reg = <0x0 0x1f03800 0x0 0x3c>;
+			pwm-number = <0x1>;
+			pwm-base = <0x10>;
+			pwms = <0x72>;
+		};
+
+		spwm0@0x01f03800 {
+			compatible = "allwinner,sunxi-pwm16";
+			pinctrl-names = "active", "sleep";
+			reg_base = <0x1f03800>;
+			reg_busy_offset = <0x0>;
+			reg_busy_shift = <0x1c>;
+			reg_enable_offset = <0x0>;
+			reg_enable_shift = <0x4>;
+			reg_clk_gating_offset = <0x0>;
+			reg_clk_gating_shift = <0x6>;
+			reg_bypass_offset = <0x0>;
+			reg_bypass_shift = <0x9>;
+			reg_pulse_start_offset = <0x0>;
+			reg_pulse_start_shift = <0x8>;
+			reg_mode_offset = <0x0>;
+			reg_mode_shift = <0x7>;
+			reg_polarity_offset = <0x0>;
+			reg_polarity_shift = <0x5>;
+			reg_period_offset = <0x4>;
+			reg_period_shift = <0x10>;
+			reg_period_width = <0x10>;
+			reg_active_offset = <0x4>;
+			reg_active_shift = <0x0>;
+			reg_active_width = <0x10>;
+			reg_prescal_offset = <0x0>;
+			reg_prescal_shift = <0x0>;
+			reg_prescal_width = <0x4>;
+			linux,phandle = <0x72>;
+			phandle = <0x72>;
+			device_type = "spwm0";
+			s_pwm_used = <0x1>;
+			pinctrl-0 = <0xaf>;
+			pinctrl-1 = <0xb0>;
+		};
+
+		boot_disp {
+			compatible = "allwinner,boot_disp";
+			device_type = "boot_disp";
+			output_disp = <0x0>;
+			output_type = <0x1>;
+			output_mode = <0x4>;
+		};
+
+		cci@0x01cb3000 {
+			compatible = "allwinner,sunxi-csi_cci";
+			reg = <0x0 0x1cb3000 0x0 0x1000>;
+			interrupts = <0x0 0x55 0x4>;
+			status = "okay";
+		};
+
+		csi_res@0x01cb0000 {
+			compatible = "allwinner,sunxi-csi";
+			reg = <0x0 0x1cb0000 0x0 0x1000>;
+			status = "okay";
+		};
+
+		vfe@0 {
+			device_type = "csi0";
+			compatible = "allwinner,sunxi-vfe";
+			interrupts = <0x0 0x54 0x4>;
+			clocks = <0x73 0x74 0x75 0x4 0x6 0x5>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x77>;
+			csi0_sensor_list = <0x1>;
+			status = "okay";
+			pinctrl-0 = <0xb1>;
+			csi0_mck = <0x30 0x4 0x1 0x0 0x0 0x1 0x0>;
+
+			dev@0 {
+				csi0_dev0_mname = "s5k4ec";
+				csi0_dev0_twi_addr = <0x5a>;
+				csi0_dev0_pos = "rear";
+				csi0_dev0_isp_used = <0x1>;
+				csi0_dev0_fmt = <0x0>;
+				csi0_dev0_stby_mode = <0x1>;
+				csi0_dev0_vflip = <0x0>;
+				csi0_dev0_hflip = <0x0>;
+				csi0_dev0_iovdd = "iovdd-csi";
+				csi0_dev0_iovdd_vol = <0x2ab980>;
+				csi0_dev0_avdd = "avdd-csi";
+				csi0_dev0_avdd_vol = <0x2ab980>;
+				csi0_dev0_dvdd = "dvdd-csi-18";
+				csi0_dev0_dvdd_vol = <0x16e360>;
+				csi0_dev0_flash_used = <0x0>;
+				csi0_dev0_flash_type = <0x2>;
+				csi0_dev0_flvdd = "vdd-csi-led";
+				csi0_dev0_flvdd_vol = <0x325aa0>;
+				csi0_dev0_act_used = <0x0>;
+				csi0_dev0_act_name = "ad5820_act";
+				csi0_dev0_act_slave = <0x18>;
+				status = "disabled";
+				device_type = "csi0_dev0";
+				csi0_dev0_afvdd;
+				csi0_dev0_afvdd_vol;
+				csi0_dev0_power_en;
+				csi0_dev0_reset = <0x30 0x4 0x10 0x0 0x0 0x1 0x0>;
+				csi0_dev0_pwdn = <0x30 0x4 0x11 0x0 0x0 0x1 0x0>;
+				csi0_dev0_flash_en;
+				csi0_dev0_flash_mode;
+				csi0_dev0_af_pwdn;
+			};
+
+			dev@1 {
+				csi0_dev1_mname = "gc2145";
+				csi0_dev1_twi_addr = <0x78>;
+				csi0_dev1_pos = "front";
+				csi0_dev1_isp_used = <0x1>;
+				csi0_dev1_fmt = <0x0>;
+				csi0_dev1_stby_mode = <0x1>;
+				csi0_dev1_vflip = <0x0>;
+				csi0_dev1_hflip = <0x0>;
+				csi0_dev1_iovdd = "iovdd-csi";
+				csi0_dev1_iovdd_vol = <0x2ab980>;
+				csi0_dev1_avdd = "avdd-csi";
+				csi0_dev1_avdd_vol = <0x2ab980>;
+				csi0_dev1_dvdd = "dvdd-csi-18";
+				csi0_dev1_dvdd_vol = <0x1b7740>;
+				csi0_dev1_flash_used = <0x0>;
+				csi0_dev1_flash_type = <0x2>;
+				csi0_dev1_flvdd = "vdd-csi-led";
+				csi0_dev1_flvdd_vol = <0x325aa0>;
+				csi0_dev1_act_used = <0x0>;
+				csi0_dev1_act_name = "ad5820_act";
+				csi0_dev1_act_slave = <0x18>;
+				status = "disabled";
+				device_type = "csi0_dev1";
+				csi0_dev1_afvdd;
+				csi0_dev1_afvdd_vol;
+				csi0_dev1_power_en;
+				csi0_dev1_reset = <0x30 0x4 0x10 0x0 0x0 0x1 0x0>;
+				csi0_dev1_pwdn = <0x30 0x4 0x11 0x0 0x0 0x1 0x0>;
+				csi0_dev1_flash_en;
+				csi0_dev1_flash_mode;
+				csi0_dev1_af_pwdn;
+			};
+		};
+
+		vdevice@0 {
+			compatible = "allwinner,sun50i-vdevice";
+			pinctrl-names = "default";
+			test-gpios = <0x79 0xb 0x0 0x1 0x2 0x3 0x4>;
+			status = "okay";
+			device_type = "Vdevice";
+			pinctrl-0 = <0xb9>;
+		};
+
+		onewire_device@0 {
+			compatible = "w1-gpio";
+			gpios = <0x30 0x2 0x8 0x0 0x0 0x0 0x0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0xba>;
+			status = "okay";
+		};
+
+		ce@1c15000 {
+			compatible = "allwinner,sunxi-ce";
+			reg = <0x0 0x1c15000 0x0 0x80 0x0 0x1c15800 0x0 0x80>;
+			interrupts = <0x0 0x5e 0xff01 0x0 0x50 0xff01>;
+			clock-frequency = <0x11e1a300 0xbebc200>;
+			clocks = <0x7a 0x7b>;
+		};
+
+		deinterlace@0x01e00000 {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			compatible = "allwinner,sunxi-deinterlace";
+			reg = <0x0 0x1e00000 0x0 0x77c>;
+			interrupts = <0x0 0x5d 0x4>;
+			clocks = <0x7c 0x4>;
+			status = "okay";
+			device_type = "di";
+		};
+
+		smartcard@0x01c2c400 {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			compatible = "allwinner,sunxi-scr";
+			reg = <0x0 0x1c2c400 0x0 0x100>;
+			interrupts = <0x0 0x53 0x4>;
+			clocks = <0x7d 0x7e>;
+			clock-frequency = <0x16e3600>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x7f>;
+			status = "okay";
+			device_type = "smc";
+			smc_used;
+			smc_rst;
+			smc_vppen;
+			smc_vppp;
+			smc_det;
+			smc_vccen;
+			smc_sck;
+			smc_sda;
+		};
+
+		nmi@0x01f00c00 {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			compatible = "allwinner,sunxi-nmi";
+			reg = <0x0 0x1f00c00 0x0 0x50>;
+			nmi_irq_ctrl = <0xc>;
+			nmi_irq_en = <0x40>;
+			nmi_irq_status = <0x10>;
+			nmi_irq_mask = <0x50>;
+			status = "okay";
+		};
+
+		pmu0@0 {
+			compatible = "allwinner,pmu0";
+			device_type = "pmu0";
+			pmu_batdeten = <0x1>;
+			pmu_init_chgend_rate = <0x14>;
+			pmu_init_chg_enabled = <0x1>;
+			pmu_init_adc_freq = <0x320>;
+			pmu_init_adcts_freq = <0x320>;
+			pmu_init_chg_pretime = <0x46>;
+			pmu_init_chg_csttime = <0x2d0>;
+			pmu_batt_cap_correct = <0x1>;
+			pmu_chg_end_on_en = <0x0>;
+			pmu_pwroff_vol = <0xce4>;
+			pmu_pwron_vol = <0xa28>;
+			pmu_powkey_off_delay_time = <0x0>;
+			pmu_pwrok_time = <0x40>;
+			pmu_reset_shutdown_en = <0x1>;
+			pmu_restvol_adjust_time = <0x3c>;
+			pmu_ocv_cou_adjust_time = <0x3c>;
+			pmu_vbusen_func = <0x1>;
+			pmu_reset = <0x0>;
+			pmu_IRQ_wakeup = <0x1>;
+			pmu_hot_shutdowm = <0x1>;
+			pmu_inshort = <0x0>;
+			pmu_bat_shutdown_ltf = <0xc80>;
+			pmu_bat_shutdown_htf = <0xed>;
+			status = "okay";
+			pmu_id = <0x6>;
+			pmu_twi_addr = <0x34>;
+			pmu_twi_id = <0x1>;
+			pmu_irq_id = <0x40>;
+			pmu_chg_ic_temp = <0x0>;
+			pmu_battery_rdc = <0x58>;
+			pmu_battery_cap = <0x12c0>;
+			pmu_runtime_chgcur = <0x1c2>;
+			pmu_suspend_chgcur = <0x5dc>;
+			pmu_shutdown_chgcur = <0x5dc>;
+			pmu_init_chgvol = <0x1068>;
+			pmu_ac_vol = <0xfa0>;
+			pmu_ac_cur = <0xdac>;
+			pmu_usbpc_vol = <0x1130>;
+			pmu_usbpc_cur = <0x1f4>;
+			pmu_battery_warning_level1 = <0xf>;
+			pmu_battery_warning_level2 = <0x0>;
+			pmu_chgled_func = <0x0>;
+			pmu_chgled_type = <0x0>;
+			pmu_bat_para1 = <0x0>;
+			pmu_bat_para2 = <0x0>;
+			pmu_bat_para3 = <0x0>;
+			pmu_bat_para4 = <0x0>;
+			pmu_bat_para5 = <0x0>;
+			pmu_bat_para6 = <0x0>;
+			pmu_bat_para7 = <0x1>;
+			pmu_bat_para8 = <0x1>;
+			pmu_bat_para9 = <0x2>;
+			pmu_bat_para10 = <0x3>;
+			pmu_bat_para11 = <0x4>;
+			pmu_bat_para12 = <0xa>;
+			pmu_bat_para13 = <0x11>;
+			pmu_bat_para14 = <0x1a>;
+			pmu_bat_para15 = <0x29>;
+			pmu_bat_para16 = <0x2e>;
+			pmu_bat_para17 = <0x33>;
+			pmu_bat_para18 = <0x38>;
+			pmu_bat_para19 = <0x3b>;
+			pmu_bat_para20 = <0x41>;
+			pmu_bat_para21 = <0x45>;
+			pmu_bat_para22 = <0x4b>;
+			pmu_bat_para23 = <0x4f>;
+			pmu_bat_para24 = <0x53>;
+			pmu_bat_para25 = <0x59>;
+			pmu_bat_para26 = <0x5f>;
+			pmu_bat_para27 = <0x62>;
+			pmu_bat_para28 = <0x64>;
+			pmu_bat_para29 = <0x64>;
+			pmu_bat_para30 = <0x64>;
+			pmu_bat_para31 = <0x64>;
+			pmu_bat_para32 = <0x64>;
+			pmu_bat_temp_enable = <0x1>;
+			pmu_bat_charge_ltf = <0x8d5>;
+			pmu_bat_charge_htf = <0x184>;
+			pmu_bat_temp_para1 = <0x1d2a>;
+			pmu_bat_temp_para2 = <0x1180>;
+			pmu_bat_temp_para3 = <0xdbe>;
+			pmu_bat_temp_para4 = <0xae2>;
+			pmu_bat_temp_para5 = <0x8af>;
+			pmu_bat_temp_para6 = <0x6fc>;
+			pmu_bat_temp_para7 = <0x5a8>;
+			pmu_bat_temp_para8 = <0x3c9>;
+			pmu_bat_temp_para9 = <0x298>;
+			pmu_bat_temp_para10 = <0x1d2>;
+			pmu_bat_temp_para11 = <0x189>;
+			pmu_bat_temp_para12 = <0x14d>;
+			pmu_bat_temp_para13 = <0x11b>;
+			pmu_bat_temp_para14 = <0xf2>;
+			pmu_bat_temp_para15 = <0xb3>;
+			pmu_bat_temp_para16 = <0x86>;
+			pmu_powkey_off_time = <0x1770>;
+			pmu_powkey_off_func = <0x0>;
+			pmu_powkey_off_en = <0x1>;
+			pmu_powkey_long_time = <0x5dc>;
+			pmu_powkey_on_time = <0x3e8>;
+			power_start = <0x0>;
+		};
+
+		regu@0 {
+			compatible = "allwinner,pmu0_regu";
+			regulator_count = <0x17>;
+			status = "okay";
+			device_type = "pmu0_regu";
+			regulator1 = "axp81x_dcdc1 none vcc-nand vcc-emmc vcc-sdc vcc-usb-30 vcc-io vcc-pd";
+			regulator2 = "axp81x_dcdc2 none vdd-cpua";
+			regulator3 = "axp81x_dcdc3 none";
+			regulator4 = "axp81x_dcdc4 none";
+			regulator5 = "axp81x_dcdc5 none vcc-dram";
+			regulator6 = "axp81x_dcdc6 none vdd-sys";
+			regulator7 = "axp81x_dcdc7 none";
+			regulator8 = "axp81x_rtc none";
+			regulator9 = "axp81x_aldo1 none vdd-csi-led iovdd-csi vcc-pe";
+			regulator10 = "axp81x_aldo2 none vcc-pl";
+			regulator11 = "axp81x_aldo3 none vcc-avcc vcc-pll";
+			regulator12 = "axp81x_dldo1 none vcc-hdmi-33";
+			regulator13 = "axp81x_dldo2 none vcc-mipi";
+			regulator14 = "axp81x_dldo3 none avdd-csi";
+			regulator15 = "axp81x_dldo4 none vcc-deviceio";
+			regulator16 = "axp81x_eldo1 none vcc-cpvdd vcc-wifi-io vcc-pc vcc-pg";
+			regulator17 = "axp81x_eldo2 none vcc-lcd-0";
+			regulator18 = "axp81x_eldo3 none dvdd-csi-18";
+			regulator19 = "axp81x_fldo1 none vcc-hsic-12";
+			regulator20 = "axp81x_fldo2 none vdd-cpus";
+			regulator21 = "axp81x_gpio0ldo none vcc-ctp";
+			regulator22 = "axp81x_gpio1ldo none";
+			regulator23 = "axp81x_dc1sw none vcc-lvds vcc-dsi-33";
+		};
+
+		nand0@01c03000 {
+			compatible = "allwinner,sun50i-nand";
+			device_type = "nand0";
+			reg = <0x0 0x1c03000 0x0 0x1000>;
+			interrupts = <0x0 0x46 0x4>;
+			clocks = <0x4 0x80>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-1 = <0x83>;
+			nand0_regulator1 = "vcc-nand";
+			nand0_regulator2 = "none";
+			nand0_cache_level = <0x55aaaa55>;
+			nand0_flush_cache_num = <0x55aaaa55>;
+			nand0_capacity_level = <0x55aaaa55>;
+			nand0_id_number_ctl = <0x55aaaa55>;
+			nand0_print_level = <0x55aaaa55>;
+			nand0_p0 = <0x55aaaa55>;
+			nand0_p1 = <0x55aaaa55>;
+			nand0_p2 = <0x55aaaa55>;
+			nand0_p3 = <0x55aaaa55>;
+			status = "disabled";
+			nand0_support_2ch = <0x0>;
+			pinctrl-0 = <0xab 0xac>;
+		};
+
+		thermal_sensor {
+			compatible = "allwinner,thermal_sensor";
+			reg = <0x0 0x1c25000 0x0 0x400>;
+			interrupts = <0x0 0x1f 0x0>;
+			clocks = <0x6 0x84>;
+			sensor_num = <0x3>;
+			shut_temp = <0x78>;
+			status = "okay";
+
+			combine0 {
+				#thermal-sensor-cells = <0x1>;
+				combine_cnt = <0x3>;
+				combine_type = "max";
+				combine_chn = <0x0 0x1 0x2>;
+				linux,phandle = <0x85>;
+				phandle = <0x85>;
+			};
+		};
+
+		cpu_budget_cool {
+			compatible = "allwinner,budget_cooling";
+			#cooling-cells = <0x2>;
+			status = "okay";
+			state_cnt = <0xa>;
+			cluster_num = <0x1>;
+			state0 = <0x119400 0x4>;
+			state1 = <0x10d880 0x4>;
+			state2 = <0x101d00 0x4>;
+			state3 = <0xf6180 0x4>;
+			state4 = <0xea600 0x4>;
+			state5 = <0xdea80 0x4>;
+			state6 = <0xc7380 0x4>;
+			state7 = <0x9e340 0x4>;
+			state8 = <0x9e340 0x2>;
+			state9 = <0x9e340 0x1>;
+			linux,phandle = <0x87>;
+			phandle = <0x87>;
+		};
+
+		gpu_cooling {
+			compatible = "allwinner,gpu_cooling";
+			reg = <0x0 0x0 0x0 0x0>;
+			#cooling-cells = <0x2>;
+			status = "okay";
+			state_cnt = <0x3>;
+			state0 = <0x0>;
+			state1 = <0x168>;
+			state2 = <0x90>;
+			linux,phandle = <0x8c>;
+			phandle = <0x8c>;
+		};
+
+		thermal-zones {
+
+			soc_thermal {
+				polling-delay-passive = <0x1f4>;
+				polling-delay = <0x7d0>;
+				thermal-sensors = <0x85 0x0>;
+
+				trips {
+
+					t0 {
+						temperature = <0x50>;
+						type = "passive";
+						hysteresis = <0x0>;
+						linux,phandle = <0x86>;
+						phandle = <0x86>;
+					};
+
+					t1 {
+						temperature = <0x55>;
+						type = "passive";
+						hysteresis = <0x0>;
+						linux,phandle = <0x88>;
+						phandle = <0x88>;
+					};
+
+					t2 {
+						temperature = <0x5a>;
+						type = "passive";
+						hysteresis = <0x0>;
+						linux,phandle = <0x89>;
+						phandle = <0x89>;
+					};
+
+					t3 {
+						temperature = <0x5f>;
+						type = "passive";
+						hysteresis = <0x0>;
+						linux,phandle = <0x8a>;
+						phandle = <0x8a>;
+					};
+
+					t4 {
+						temperature = <0x55>;
+						type = "passive";
+						hysteresis = <0x0>;
+						linux,phandle = <0x8b>;
+						phandle = <0x8b>;
+					};
+
+					t5 {
+						temperature = <0x5a>;
+						type = "passive";
+						hysteresis = <0x0>;
+						linux,phandle = <0x8d>;
+						phandle = <0x8d>;
+					};
+
+					t6 {
+						temperature = <0x6c>;
+						type = "critical";
+						hysteresis = <0x0>;
+					};
+				};
+
+				cooling-maps {
+
+					bind0 {
+						contribution = <0x0>;
+						trip = <0x86>;
+						cooling-device = <0x87 0x1 0x1>;
+					};
+
+					bind1 {
+						contribution = <0x0>;
+						trip = <0x88>;
+						cooling-device = <0x87 0x2 0x2>;
+					};
+
+					bind2 {
+						contribution = <0x0>;
+						trip = <0x89>;
+						cooling-device = <0x87 0x3 0x6>;
+					};
+
+					bind3 {
+						contribution = <0x0>;
+						trip = <0x8a>;
+						cooling-device = <0x87 0x7 0x9>;
+					};
+
+					bind4 {
+						contribution = <0x0>;
+						trip = <0x8b>;
+						cooling-device = <0x8c 0x1 0x1>;
+					};
+
+					bind5 {
+						contribution = <0x0>;
+						trip = <0x8d>;
+						cooling-device = <0x8c 0x2 0x2>;
+					};
+				};
+			};
+		};
+
+		keyboard {
+			compatible = "allwinner,keyboard_2000mv";
+			reg = <0x0 0x1c21800 0x0 0x400>;
+			interrupts = <0x0 0x1e 0x0>;
+			status = "okay";
+			key_cnt = <0x5>;
+			key1 = <0xf0 0x73>;
+			key2 = <0x1f4 0x72>;
+			key3 = <0x2bc 0x8b>;
+			key4 = <0x37a 0x1c>;
+			key5 = <0x7d0 0x66>;
+		};
+
+		eth@01c30000 {
+			compatible = "allwinner,sunxi-gmac";
+			reg = <0x0 0x1c30000 0x0 0x10000 0x0 0x1c00000 0x0 0x30>;
+			pinctrl-names = "default";
+			interrupts = <0x0 0x52 0x4>;
+			interrupt-names = "gmacirq";
+			clocks = <0x8f>;
+			clock-names = "gmac";
+			phy-mode = "rgmii";
+			tx-delay = <0x3>;
+			rx-delay = <0x0>;
+			gmac_power1 = "axp81x_dc1sw:0";
+			status = "okay";
+			device_type = "gmac0";
+			pinctrl-0 = <0x9e>;
+			gmac_power2;
+			gmac_power3;
+		};
+
+		product {
+			device_type = "product";
+			version = "100";
+			machine = "evb";
+		};
+
+		platform {
+			device_type = "platform";
+			eraseflag = <0x1>;
+		};
+
+		target {
+			device_type = "target";
+			boot_clock = <0x3f0>;
+			storage_type = <0xffffffff>;
+			burn_key = <0x0>;
+		};
+
+		power_sply {
+			device_type = "power_sply";
+			dcdc1_vol = <0xf4f24>;
+			dcdc2_vol = <0xf468c>;
+			dcdc6_vol = <0xf468c>;
+			aldo1_vol = <0xaf0>;
+			aldo2_vol = <0xf4948>;
+			aldo3_vol = <0xf4df8>;
+			dldo1_vol = <0xce4>;
+			dldo2_vol = <0xce4>;
+			dldo3_vol = <0xaf0>;
+			dldo4_vol = <0xf4f24>;
+			eldo1_vol = <0xf4948>;
+			eldo2_vol = <0x708>;
+			eldo3_vol = <0x708>;
+			fldo1_vol = <0x4b0>;
+			fldo2_vol = <0xf468c>;
+			gpio0_vol = <0xc1c>;
+		};
+
+		card_boot {
+			device_type = "card_boot";
+			logical_start = <0xa000>;
+			sprite_gpio0;
+		};
+
+		pm_para {
+			device_type = "pm_para";
+			standby_mode = <0x1>;
+		};
+
+		card0_boot_para {
+			device_type = "card0_boot_para";
+			card_ctrl = <0x0>;
+			card_high_speed = <0x1>;
+			card_line = <0x4>;
+			pinctrl-0 = <0x99>;
+		};
+
+		card2_boot_para {
+			device_type = "card2_boot_para";
+			sdc_io_1v8 = <0x1>;
+			card_ctrl = <0x2>;
+			card_high_speed = <0x1>;
+			card_line = <0x8>;
+			pinctrl-0 = <0x9a>;
+			sdc_ex_dly_used = <0x2>;
+		};
+
+		twi_para {
+			device_type = "twi_para";
+			twi_port = <0x0>;
+			pinctrl-0 = <0x9b>;
+		};
+
+		uart_para {
+			device_type = "uart_para";
+			uart_debug_port = <0x0>;
+			pinctrl-0 = <0x9c>;
+		};
+
+		jtag_para {
+			device_type = "jtag_para";
+			jtag_enable = <0x1>;
+			pinctrl-0 = <0x9d>;
+		};
+
+		clock {
+			device_type = "clock";
+			pll4 = <0x12c>;
+			pll6 = <0x258>;
+			pll8 = <0x168>;
+			pll9 = <0x129>;
+			pll10 = <0x108>;
+		};
+
+		rtp_para {
+			device_type = "rtp_para";
+			rtp_used = <0x0>;
+			rtp_screen_size = <0x5>;
+			rtp_regidity_level = <0x5>;
+			rtp_press_threshold_enable = <0x0>;
+			rtp_press_threshold = <0x1f40>;
+			rtp_sensitive_level = <0xf>;
+			rtp_exchange_x_y_flag = <0x0>;
+		};
+
+		ctp {
+			device_type = "ctp";
+			compatible = "allwinner,sun50i-ctp-para";
+			status = "disabled";
+			ctp_name = "gt911_DB";
+			ctp_twi_id = <0x0>;
+			ctp_twi_addr = <0x40>;
+			ctp_screen_max_x = <0x400>;
+			ctp_screen_max_y = <0x258>;
+			ctp_revert_x_flag = <0x1>;
+			ctp_revert_y_flag = <0x1>;
+			ctp_exchange_x_y_flag = <0x0>;
+			ctp_int_port = <0x30 0x7 0x4 0x6 0xffffffff 0xffffffff 0xffffffff>;
+			ctp_wakeup = <0x30 0x7 0xb 0x1 0xffffffff 0xffffffff 0x1>;
+			ctp_power_ldo = "vcc-ctp";
+			ctp_power_ldo_vol = <0xce4>;
+			ctp_power_io;
+		};
+
+		ctp_list {
+			device_type = "ctp_list";
+			compatible = "allwinner,sun50i-ctp-list";
+			status = "okay";
+			gslX680new = <0x1>;
+			gt9xx_ts = <0x0>;
+			gt9xxf_ts = <0x1>;
+			gt9xxnew_ts = <0x0>;
+			gt82x = <0x1>;
+			zet622x = <0x1>;
+			aw5306_ts = <0x1>;
+		};
+
+		tkey_para {
+			device_type = "tkey_para";
+			tkey_used = <0x0>;
+			tkey_twi_id;
+			tkey_twi_addr;
+			tkey_int;
+		};
+
+		motor_para {
+			device_type = "motor_para";
+			motor_used = <0x0>;
+			motor_shake = <0x31 0xfffe 0x3 0x1 0xffffffff 0xffffffff 0x1>;
+		};
+
+		tvout_para {
+			device_type = "tvout_para";
+			tvout_used;
+			tvout_channel_num;
+			tv_en;
+		};
+
+		tvin_para {
+			device_type = "tvin_para";
+			tvin_used;
+			tvin_channel_num;
+		};
+
+		serial_feature {
+			device_type = "serial_feature";
+			sn_filename = "sn.txt";
+		};
+
+		gsensor {
+			device_type = "gsensor";
+			compatible = "allwinner,sun50i-gsensor-para";
+			status = "okay";
+			gsensor_twi_id = <0x1>;
+			gsensor_twi_addr = <0x1d>;
+			gsensor_vcc_io = "vcc-deviceio";
+			gsensor_vcc_io_val = <0xce4>;
+			gsensor_int1 = <0x30 0x7 0x5 0x6 0x1 0xffffffff 0xffffffff>;
+			gsensor_int2 = <0x30 0x7 0x6 0x6 0x1 0xffffffff 0xffffffff>;
+		};
+
+		gsensor_list {
+			device_type = "gsensor_list";
+			compatible = "allwinner,sun50i-gsensor-list-para";
+			gsensor_list__used = <0x1>;
+			lsm9ds0_acc_mag = <0x1>;
+			bma250 = <0x1>;
+			mma8452 = <0x1>;
+			mma7660 = <0x1>;
+			mma865x = <0x1>;
+			afa750 = <0x1>;
+			lis3de_acc = <0x1>;
+			lis3dh_acc = <0x1>;
+			kxtik = <0x1>;
+			dmard10 = <0x0>;
+			dmard06 = <0x1>;
+			mxc622x = <0x1>;
+			fxos8700 = <0x1>;
+			lsm303d = <0x0>;
+			sc7a30 = <0x1>;
+		};
+
+		3g_para {
+			device_type = "3g_para";
+			3g_used = <0x0>;
+			3g_usbc_num = <0x2>;
+			3g_uart_num = <0x0>;
+			bb_vbat = <0x79 0xb 0x3 0x1 0xffffffff 0xffffffff 0x0>;
+			bb_host_wake = <0x79 0xc 0x0 0x1 0xffffffff 0xffffffff 0x0>;
+			bb_on = <0x79 0xc 0x1 0x1 0xffffffff 0xffffffff 0x0>;
+			bb_pwr_on = <0x79 0xc 0x3 0x1 0xffffffff 0xffffffff 0x0>;
+			bb_wake = <0x79 0xc 0x4 0x1 0xffffffff 0xffffffff 0x0>;
+			bb_rf_dis = <0x79 0xc 0x5 0x1 0xffffffff 0xffffffff 0x0>;
+			bb_rst = <0x79 0xc 0x6 0x1 0xffffffff 0xffffffff 0x0>;
+			3g_int;
+		};
+
+		gyroscopesensor {
+			device_type = "gyroscopesensor";
+			compatible = "allwinner,sun50i-gyr_sensors-para";
+			status = "disabled";
+			gy_twi_id = <0x2>;
+			gy_twi_addr = <0x6a>;
+			gy_int1 = <0x30 0x0 0xa 0x6 0x1 0xffffffff 0xffffffff>;
+			gy_int2;
+		};
+
+		gy_list {
+			device_type = "gy_list";
+			compatible = "allwinner,sun50i-gyr_sensors-list-para";
+			status = "disabled";
+			lsm9ds0_gyr = <0x1>;
+			l3gd20_gyr = <0x0>;
+			bmg160_gyr = <0x1>;
+		};
+
+		lightsensor {
+			device_type = "lightsensor";
+			compatible = "allwinner,sun50i-lsensors-para";
+			status = "disabled";
+			ls_twi_id = <0x2>;
+			ls_twi_addr = <0x23>;
+			ls_int = <0x30 0x0 0xc 0x6 0x1 0xffffffff 0xffffffff>;
+		};
+
+		ls_list {
+			device_type = "ls_list";
+			compatible = "allwinner,sun50i-lsensors-list-para";
+			status = "disabled";
+			ltr_501als = <0x1>;
+			jsa1212 = <0x0>;
+			jsa1127 = <0x1>;
+			stk3x1x = <0x0>;
+		};
+
+		compasssensor {
+			device_type = "compasssensor";
+			compatible = "allwinner,sun50i-compass-para";
+			status = "disabled";
+			compass_twi_id = <0x2>;
+			compass_twi_addr = <0xd>;
+			compass_int = <0x30 0x0 0xb 0x6 0x1 0xffffffff 0xffffffff>;
+		};
+
+		compass_list {
+			device_type = "compass_list";
+			compatible = "allwinner,sun50i-compass-list-para";
+			status = "disabled";
+			lsm9ds0 = <0x1>;
+			lsm303d = <0x0>;
+		};
+
+		recovery_key {
+			device_type = "recovery_key";
+			key_max = <0xc>;
+			key_min = <0xa>;
+		};
+
+		fastboot_key {
+			device_type = "fastboot_key";
+			key_max = <0x6>;
+			key_min = <0x4>;
+		};
+	};
+
+	aliases {
+		serial0 = "/soc@01c00000/uart@01c28000";
+		serial1 = "/soc@01c00000/uart@01c28400";
+		serial2 = "/soc@01c00000/uart@01c28800";
+		serial3 = "/soc@01c00000/uart@01c28c00";
+		serial4 = "/soc@01c00000/uart@01c29000";
+		twi0 = "/soc@01c00000/twi@0x01c2ac00";
+		twi1 = "/soc@01c00000/twi@0x01c2b000";
+		twi2 = "/soc@01c00000/twi@0x01c2b400";
+		spi0 = "/soc@01c00000/spi@01c68000";
+		spi1 = "/soc@01c00000/spi@01c69000";
+		global_timer0 = "/soc@01c00000/timer@1c20c00";
+		cci0 = "/soc@01c00000/cci@0x01cb3000";
+		csi_res0 = "/soc@01c00000/csi_res@0x01cb0000";
+		vfe0 = "/soc@01c00000/vfe@0";
+		mmc0 = "/soc@01c00000/sdmmc@01c0f000";
+		mmc2 = "/soc@01c00000/sdmmc@01C11000";
+		nand0 = "/soc@01c00000/nand0@01c03000";
+		disp = "/soc@01c00000/disp@01000000";
+		lcd0 = "/soc@01c00000/lcd0@01c0c000";
+		hdmi = "/soc@01c00000/hdmi@01ee0000";
+		pwm = "/soc@01c00000/pwm@01c21400";
+		pwm0 = "/soc@01c00000/pwm0@01c21400";
+		s_pwm = "/soc@01c00000/s_pwm@1f03800";
+		spwm0 = "/soc@01c00000/spwm0@0x01f03800";
+		boot_disp = "/soc@01c00000/boot_disp";
+	};
+
+	chosen {
+		bootargs = "earlyprintk=sunxi-uart,0x01c28000 loglevel=8 initcall_debug=1 console=ttyS0 init=/init";
+		linux,initrd-start = <0x0 0x0>;
+		linux,initrd-end = <0x0 0x0>;
+	};
+
+	cpus {
+		#address-cells = <0x2>;
+		#size-cells = <0x0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53", "arm,armv8";
+			reg = <0x0 0x0>;
+			enable-method = "psci";
+			cpufreq_tbl = <0x75300 0x927c0 0xafc80 0xc7380 0xdea80 0xea600 0xf6180 0x101d00 0x10d880 0x119400 0x124f80 0x148200>;
+			clock-latency = <0x1e8480>;
+			clock-frequency = <0x3c14dc00>;
+			cpu-idle-states = <0x90 0x91 0x92>;
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53", "arm,armv8";
+			reg = <0x0 0x1>;
+			enable-method = "psci";
+			clock-frequency = <0x3c14dc00>;
+			cpu-idle-states = <0x90 0x91 0x92>;
+		};
+
+		cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53", "arm,armv8";
+			reg = <0x0 0x2>;
+			enable-method = "psci";
+			clock-frequency = <0x3c14dc00>;
+			cpu-idle-states = <0x90 0x91 0x92>;
+		};
+
+		cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53", "arm,armv8";
+			reg = <0x0 0x3>;
+			enable-method = "psci";
+			clock-frequency = <0x3c14dc00>;
+			cpu-idle-states = <0x90 0x91 0x92>;
+		};
+
+		idle-states {
+			entry-method = "arm,psci";
+
+			cpu-sleep-0 {
+				compatible = "arm,idle-state";
+				arm,psci-suspend-param = <0x10000>;
+				entry-latency-us = <0x28>;
+				exit-latency-us = <0x64>;
+				min-residency-us = <0x96>;
+				linux,phandle = <0x90>;
+				phandle = <0x90>;
+			};
+
+			cluster-sleep-0 {
+				compatible = "arm,idle-state";
+				arm,psci-suspend-param = <0x1010000>;
+				entry-latency-us = <0x1f4>;
+				exit-latency-us = <0x3e8>;
+				min-residency-us = <0x9c4>;
+				linux,phandle = <0x91>;
+				phandle = <0x91>;
+			};
+
+			sys-sleep-0 {
+				compatible = "arm,idle-state";
+				arm,psci-suspend-param = <0x2010000>;
+				entry-latency-us = <0x3e8>;
+				exit-latency-us = <0x7d0>;
+				min-residency-us = <0x1194>;
+				linux,phandle = <0x92>;
+				phandle = <0x92>;
+			};
+		};
+	};
+
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "smc";
+		psci_version = <0x84000000>;
+		cpu_suspend = <0xc4000001>;
+		cpu_off = <0x84000002>;
+		cpu_on = <0xc4000003>;
+		affinity_info = <0xc4000004>;
+		migrate = <0xc4000005>;
+		migrate_info_type = <0x84000006>;
+		migrate_info_up_cpu = <0xc4000007>;
+		system_off = <0x84000008>;
+		system_reset = <0x84000009>;
+	};
+
+	n_brom {
+		compatible = "allwinner,n-brom";
+		reg = <0x0 0x0 0x0 0xc000>;
+	};
+
+	s_brom {
+		compatible = "allwinner,s-brom";
+		reg = <0x0 0x0 0x0 0x10000>;
+	};
+
+	sram_a1 {
+		compatible = "allwinner,sram_a1";
+		reg = <0x0 0x10000 0x0 0x8000>;
+	};
+
+	sram_a2 {
+		compatible = "allwinner,sram_a2";
+		reg = <0x0 0x40000 0x0 0x14000>;
+	};
+
+	prcm {
+		compatible = "allwinner,prcm";
+		reg = <0x0 0x1f01400 0x0 0x400>;
+	};
+
+	cpuscfg {
+		compatible = "allwinner,cpuscfg";
+		reg = <0x0 0x1f01c00 0x0 0x400>;
+	};
+
+	ion {
+		compatible = "allwinner,sunxi-ion";
+
+		system_contig {
+			type = <0x1>;
+		};
+
+		cma {
+			type = <0x4>;
+		};
+
+		system {
+			type = <0x0>;
+		};
+	};
+
+	dram {
+		compatible = "allwinner,dram";
+		clocks = <0x93 0x94>;
+		clock-names = "pll_ddr0", "pll_ddr1";
+		dram_clk = <0x2a0>;
+		dram_type = <0x3>;
+		dram_zq = <0x3b3bdd>;
+		dram_odt_en = <0x1>;
+		dram_para1 = <0x10e40400>;
+		dram_para2 = <0x4000000>;
+		dram_mr0 = <0x1c70>;
+		dram_mr1 = <0x40>;
+		dram_mr2 = <0x18>;
+		dram_mr3 = <0x0>;
+		dram_tpr0 = <0x48a192>;
+		dram_tpr1 = <0x1c2418d>;
+		dram_tpr2 = <0x76051>;
+		dram_tpr3 = <0x50005dc>;
+		dram_tpr4 = <0x0>;
+		dram_tpr5 = <0x0>;
+		dram_tpr6 = <0x0>;
+		dram_tpr7 = <0x2a066198>;
+		dram_tpr8 = <0x0>;
+		dram_tpr9 = <0x0>;
+		dram_tpr10 = <0x8808>;
+		dram_tpr11 = <0x40a60066>;
+		dram_tpr12 = <0x55550000>;
+		dram_tpr13 = <0x4000903>;
+		device_type = "dram";
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0x0 0x41000000 0x0 0x3f000000>;
+	};
+
+	interrupt-controller@1c81000 {
+		compatible = "arm,cortex-a15-gic", "arm,cortex-a9-gic";
+		#interrupt-cells = <0x3>;
+		#address-cells = <0x0>;
+		device_type = "gic";
+		interrupt-controller;
+		reg = <0x0 0x1c81000 0x0 0x1000 0x0 0x1c82000 0x0 0x2000 0x0 0x1c84000 0x0 0x2000 0x0 0x1c86000 0x0 0x2000>;
+		interrupts = <0x1 0x9 0xf04>;
+		linux,phandle = <0x1>;
+		phandle = <0x1>;
+	};
+
+	sunxi-chipid@1c14200 {
+		compatible = "sunxi,sun50i-chipid";
+		device_type = "chipid";
+		reg = <0x0 0x1c14200 0x0 0x400>;
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupts = <0x1 0xd 0xff01 0x1 0xe 0xff01 0x1 0xb 0xff01 0x1 0xa 0xff01>;
+		clock-frequency = <0x16e3600>;
+	};
+
+	pmu {
+		compatible = "arm,armv8-pmuv3";
+		interrupts = <0x0 0x78 0x4 0x0 0x79 0x4 0x0 0x7a 0x4 0x0 0x7b 0x4>;
+	};
+
+	dvfs_table {
+		compatible = "allwinner,dvfs_table";
+		max_freq = <0x44aa2000>;
+		min_freq = <0x1c9c3800>;
+		lv_count = <0x8>;
+		lv1_freq = <0x44aa2000>;
+		lv1_volt = <0x514>;
+		lv2_freq = <0x41cdb400>;
+		lv2_volt = <0x4ec>;
+		lv3_freq = <0x3ef14800>;
+		lv3_volt = <0x4d8>;
+		lv4_freq = <0x3c14dc00>;
+		lv4_volt = <0x4b0>;
+		lv5_freq = "98p";
+		lv5_volt = <0x488>;
+		lv6_freq = <0x365c0400>;
+		lv6_volt = <0x460>;
+		lv7_freq = <0x30a32c00>;
+		lv7_volt = <0x438>;
+		lv8_freq = <0x269fb200>;
+		lv8_volt = <0x410>;
+		device_type = "dvfs_table";
+	};
+
+	dramfreq {
+		compatible = "allwinner,sunxi-dramfreq";
+		reg = <0x0 0x1c62000 0x0 0x1000 0x0 0x1c63000 0x0 0x1000 0x0 0x1c20000 0x0 0x800>;
+		clocks = <0x93 0x94 0x95>;
+		status = "okay";
+	};
+
+	uboot {
+	};
+
+	gpu@0x01c40000 {
+		compatible = "arm,mali-400", "arm,mali-utgard";
+		reg = <0x0 0x1c40000 0x0 0x10000>;
+		interrupts = <0x0 0x61 0x4 0x0 0x62 0x4 0x0 0x63 0x4 0x0 0x64 0x4 0x0 0x66 0x4 0x0 0x67 0x4>;
+		interrupt-names = "IRQGP", "IRQGPMMU", "IRQPP0", "IRQPPMMU0", "IRQPP1", "IRQPPMMU1";
+		clocks = <0x96 0x97>;
+		device_type = "gpu_mali400_0";
+		normal_freq = <0x198>;
+		scene_ctrl_status = <0x0>;
+		temp_ctrl_status = <0x1>;
+	};
+
+	wlan {
+		compatible = "allwinner,sunxi-wlan";
+		wlan_io_regulator = "vcc-wifi-io";
+		wlan_busnum = <0x1>;
+		status = "okay";
+		device_type = "wlan";
+		clocks;
+		wlan_power;
+		wlan_regon = <0x79 0xb 0x2 0x1 0xffffffff 0xffffffff 0x0>;
+		wlan_hostwake = <0x79 0xb 0x3 0x6 0xffffffff 0xffffffff 0x0>;
+		efuse_map_path = "wifi_efuse_8189e_for_MB1019Q5.map";
+	};
+
+	bt {
+		compatible = "allwinner,sunxi-bt";
+		bt_io_regulator = "vcc-wifi-io";
+		status = "okay";
+		device_type = "bt";
+		clocks;
+		bt_power;
+		bt_rst_n = <0x79 0xb 0x4 0x1 0xffffffff 0xffffffff 0x0>;
+	};
+
+	btlpm {
+		compatible = "allwinner,sunxi-btlpm";
+		uart_index = <0x1>;
+		status = "okay";
+		device_type = "btlpm";
+		bt_wake = <0x79 0xb 0x6 0x1 0xffffffff 0xffffffff 0x1>;
+		bt_hostwake = <0x79 0xb 0x5 0x6 0xffffffff 0xffffffff 0x0>;
+	};
+};

--- a/build-pine64-image.sh
+++ b/build-pine64-image.sh
@@ -1,20 +1,63 @@
 #!/bin/sh
 #
-# This scripts takes a simpleimage and a kernel tarball, resizes the
+# This script takes a simpleimage and a kernel tarball, resizes the
 # secondary partition and creates a rootfs inside it. Then extracts the
 # Kernel tarball on top of it, resulting in a full Pine64 disk image.
 #
-# Latest stuff can be found at the following locations:
-# -  https://www.stdin.xyz/downloads/people/longsleep/pine64-images/simpleimage-pine64-latest.img.xz
-# -  https://www.stdin.xyz/downloads/people/longsleep/pine64-images/linux/linux-pine64-latest.tar.xz"
+# If a simpleimage is not available, the script will attempt to build one.
 
-SIMPLEIMAGE="$1"
-KERNELTAR="$2"
-DISTRO="$3"
-COUNT="$4"
+TYPE="$1"
+LINUX="$2"
+OUTPUT="$3"
+DISTRO="$4"
+SIMPLEIMAGE="$5"
 
-if [ -z "$SIMPLEIMAGE" -o -z "$KERNELTAR" ]; then
-	echo "Usage: $0 <simpleimage.img.xz> <kernel.tar.xz> [distro] [count]"
+SIZE="1440" # MiB
+PWD=$(pwd)
+
+set -e
+
+if [ -z "$TYPE" -o -z "$LINUX" -o -z "$OUTPUT" ]; then
+	echo "Usage: $0 <image-type> <linux-folder-or-tarball> <destination-directory> [distro] [simpleimage.img.xz]"
+	echo ""
+	echo "Image type:"
+	echo ""
+	echo "pine64      - Pine A64"
+	echo "pine64lcd   - Pine A64 with LCD"
+	echo "sopine      - SoPine A64"
+	echo "pinebook    - Pinebook (PLACEHOLDER ONLY)"
+	echo ""
+	echo "Distros available:"
+	echo ""
+	echo "arch - Arch Linux"
+	echo "xenial - Ubuntu Linux (Xenial Xerus)"
+	echo "sid - Debian Linux (sid)"
+	echo "jessie - Debian Linux (jessie)"
+	echo "opensuse - OpenSUSE Tumbleweed"
+	echo ""
+	echo "If no distro is specified, this tool will default to xenial"
+	echo "Also, if the location to the simpleimage is not provided, the tool will try"
+	echo "to build one if the required dependecies are installed"
+	exit 1
+fi
+
+DISTRO2=$DISTRO
+
+if [ $TYPE = "pine64" ]; then
+	echo -n
+elif [ $TYPE = "pine64lcd" ]; then
+	DISTRO=${DISTRO}-lcd
+elif [ $TYPE = "sopine" ]; then
+	echo -n
+elif [ $TYPE = "pinebook" ]; then
+	echo -n
+else
+	echo "Invalid image type specified"
+	exit 2
+fi
+
+if [ ! -d "$PWD/$OUTPUT" ]; then
+	echo "$OUTPUT is not a directory."
 	exit 1
 fi
 
@@ -23,64 +66,150 @@ if [ "$(id -u)" -ne "0" ]; then
 	exit 1
 fi
 
+echo -n "Checking for presence of zerofree... "
+
+if [ -x /usr/sbin/zerofree ]; then
+	echo "OK"
+else
+	echo "Not Installed"
+	echo "ERROR: You need to install zerofree in order to generate a pine64 image."
+	exit 1
+fi
+
 if [ -z "$DISTRO" ]; then
 	DISTRO="xenial"
 fi
 
-if [ -z "$COUNT" ]; then
-	COUNT=1
+# Find a free loop device
+LOOP=$(losetup -f)
+
+if [ -d /tmp/temp-pine64 ]; then
+	rm -r /tmp/temp-pine64
 fi
 
-SIMPLEIMAGE=$(readlink -f "$SIMPLEIMAGE")
-KERNELTAR=$(readlink -f "$KERNELTAR")
-
-SIZE=3650 # MiB
-DATE=$(date +%Y%m%d_%H%M%S_%Z)
-
-PWD=$(readlink -f .)
-TEMP=$(mktemp -p $PWD -d -t "pine64-build-XXXXXXXXXX")
-IMAGE="$DISTRO-pine64-bspkernel-$DATE-$COUNT.img"
-echo "> Building in $TEMP ..."
+mkdir /tmp/temp-pine64
+mkdir /tmp/temp-pine64/rootfs
 
 cleanup() {
-    local arg=$?
-    echo "> Cleaning up ..."
-    umount "$TEMP/boot" || true
-    umount "$TEMP/rootfs" || true
-    kpartx -sd "$TEMP/$IMAGE" || true
-    rmdir "$TEMP/boot"
-    rmdir "$TEMP/rootfs"
-    rm "$TEMP/*" || true
-    rmdir "$TEMP"
-    exit $arg
+	set +e
+	umount /tmp/temp-pine64/rootfs &> /dev/null
+	losetup -d $LOOP &> /dev/null
+	rm -r /tmp/temp-pine64/ &> /dev/null
 }
 trap cleanup EXIT
 
-set -x
+check_dependecies() {
 
-# Unpack
-unxz -k --stdout "$SIMPLEIMAGE" > "$TEMP/$IMAGE"
-# Enlarge
-dd if=/dev/zero bs=1M count=$SIZE >> "$TEMP/$IMAGE"
-# Resize
-echo ", +" | sfdisk -N 2 "$TEMP/$IMAGE"
+	DEPENDECIES="0"
 
-# Device
-mkdir "$TEMP/boot"
-mkdir "$TEMP/rootfs"
-DEVICE=$(losetup --show --find "$TEMP/$IMAGE")
-DEVICENAME=$(basename $DEVICE)
-echo "> Device is $DEVICE ..."
-kpartx -avs $DEVICE
+	echo -n "Checking for presence of arm-linux-gnueabihf toolchain... "
 
-# Resize filesystem
-resize2fs /dev/mapper/${DEVICENAME}p2 || true
+	if [ -x /usr/bin/arm-linux-gnueabihf-gcc ]; then
+		echo "OK"
+	else
+		echo "Not Installed" && DEPENDECIES="1"
+	fi
 
-# Mount
-mount /dev/mapper/${DEVICENAME}p1 "$TEMP/boot"
-mount /dev/mapper/${DEVICENAME}p2 "$TEMP/rootfs"
+	echo -n "Checking for presence of aarch64-linux-gnu toolchain... "
 
-sleep 2
-(cd simpleimage && ./make_rootfs.sh "$TEMP/rootfs" "$KERNELTAR" "$DISTRO" "$TEMP/boot")
+	if [ -x /usr/bin/aarch64-linux-gnu-gcc ]; then
+		echo "OK"
+	else
+		echo "Not Installed" && DEPENDECIES="1"
+	fi
+	
+	echo -n "Checking for presence of git... "
 
-mv -v "$TEMP/$IMAGE" .
+	if [ -x /usr/bin/git ]; then
+		echo "OK"
+	else
+		echo "Not Installed" && DEPENDECIES="1"
+	fi
+
+	echo -n "Checking for presence of device-tree-compiler... "
+
+	if [ -x /usr/bin/dtc ]; then
+		echo "OK"
+	else
+		echo "Not Installed" && DEPENDECIES="1"
+	fi
+	
+	if [ $DEPENDECIES -eq 1 ]; then
+		echo "ERROR: One or more depedecies required to generate the simpleimage are not installed. Please install the missing dependecies and try again or provide a simpleimage for the tool to use"
+		exit 1
+	fi
+
+}
+
+build_simpleimage() {
+	if [ ! -d u-boot-pine64 ]; then
+		git clone https://github.com/longsleep/u-boot-pine64.git
+	fi
+	
+	if [ ! -d arm-trusted-firmware-pine64 ]; then
+		git clone https://github.com/longsleep/arm-trusted-firmware.git arm-trusted-firmware-pine64
+	fi
+
+	if [ ! -d sunxi-pack-tools ]; then
+		git clone https://github.com/longsleep/sunxi-pack-tools.git
+		make -C sunxi-pack-tools
+	fi
+
+	cd u-boot-pine64
+
+	make clean
+	git pull origin
+	make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- sun50iw1p1_config
+	make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+
+	cd ../arm-trusted-firmware-pine64
+
+	make clean
+	git pull origin
+	make ARCH=arm CROSS_COMPILE=aarch64-linux-gnu- PLAT=sun50iw1p1 bl31
+
+	cd ../u-boot-postprocess
+
+	./u-boot-postprocess.sh
+	
+	cd ../simpleimage
+
+	./make_simpleimage.sh $TYPE /tmp/temp-pine64/pine64-image.img $LINUX $SIZE
+	
+}
+
+if [ -z "$SIMPLEIMAGE" ]; then
+	echo "simpleimage is not provided. This tool will now attempt to generate a new simpleimage..."
+	check_dependecies
+	build_simpleimage
+	losetup $LOOP /tmp/temp-pine64/pine64-image.img -o $((143360 * 512))
+else
+	echo "Using the simpleimage from $SIMPLEIMAGE..."
+	# Unpack
+	unxz -k --stdout "$SIMPLEIMAGE" > "/tmp/temp-pine64/pine64-image.img"
+	# Enlarge
+	dd if=/dev/zero bs=1M count=$(($SIZE - 50)) >> "/tmp/temp-pine64/pine64-image.img"
+	# Resize
+	echo ", +" | sfdisk -N 2 "/tmp/temp-pine64/pine64-image.img"
+	losetup $LOOP /tmp/temp-pine64/pine64-image.img -o $((143360 * 512))
+	resize2fs $LOOP
+	cd simpleimage
+fi
+
+mount $LOOP /tmp/temp-pine64/rootfs
+./make_rootfs.sh /tmp/temp-pine64/rootfs $LINUX $DISTRO
+umount /tmp/temp-pine64/rootfs
+zerofree -v $LOOP
+losetup -d $LOOP
+
+cd ..
+
+mv /tmp/temp-pine64/pine64-image.img "$PWD/$OUTPUT/$DISTRO2-$TYPE-$(date +%Y%m%d).img"
+
+trap "" EXIT
+
+echo ""
+echo "#"
+echo "# The image has been built successfully"
+echo "#"
+echo ""

--- a/kernel/install_kernel.sh
+++ b/kernel/install_kernel.sh
@@ -79,10 +79,14 @@ else
 	# Not found, use device tree from BSP.
 	echo "Compiling device tree from $BLOBS/${basename}.dts"
 	dtc -Odtb -o "$DEST/$SUBFOLDER/sun50i-a64-pine64-plus.dtb" "$BLOBS/${basename}.dts"
+	echo "Compiling device tree from $BLOBS/${basename}lcd.dts"
+	dtc -Odtb -o "$DEST/$SUBFOLDER/sun50i-a64-pine64-plus-lcd.dtb" "$BLOBS/${basename}lcd.dts"
 	echo "Compiling device tree from $BLOBS/${basename}noplus.dts"
 	dtc -Odtb -o "$DEST/$SUBFOLDER/sun50i-a64-pine64.dtb" "$BLOBS/${basename}noplus.dts"
 	echo "Compiling device tree from $BLOBS/${basename}so.dts"
 	dtc -Odtb -o "$DEST/$SUBFOLDER/sun50i-a64-pine64-so.dtb" "$BLOBS/${basename}so.dts"
+	echo "Compiling device tree from $BLOBS/pinebook.dts"
+	dtc -Odtb -o "$DEST/$SUBFOLDER/sun50i-a64-pinebook.dtb" "$BLOBS/pinebook.dts"
 fi
 
 if [ ! -e "$DEST/uEnv.txt" ]; then

--- a/simpleimage/make_rootfs.sh
+++ b/simpleimage/make_rootfs.sh
@@ -17,7 +17,18 @@ DISTRO="$3"
 BOOT="$4"
 
 if [ -z "$DEST" -o -z "$LINUX" ]; then
-	echo "Usage: $0 <destination-folder> <linux-folder> [distro] [<boot-folder>]"
+	echo "Usage: $0 <destination-folder> <linux-folder-or-tarball> [distro] [boot-folder]"
+	echo ""
+	echo "Distros available:"
+	echo "arch - Arch Linux"
+	echo "xenial - Ubuntu Linux (Xenial Xerus)"
+	echo "sid - Debian Linux (sid)"
+	echo "jessie - Debian Linux (jessie)"
+	echo "opensuse - OpenSUSE Tumbleweed"
+	echo ""
+	echo "If no distro is specified, this tool will default to xenial"
+	echo "To use the LCD with your Pine, add '-lcd' to the distro"	
+
 	exit 1
 fi
 
@@ -49,12 +60,22 @@ fi
 
 TEMP=$(mktemp -d)
 cleanup() {
-	if [ -e "$DEST/proc/cmdline" ]; then
-		umount "$DEST/proc"
-	fi
-	if [ -d "$DEST/sys/kernel" ]; then
-		umount "$DEST/sys"
-	fi
+	while [ -e "$DEST/proc/cmdline" ]; do
+		umount $DEST/proc
+		sleep 2
+	done
+	while [ -d "$DEST/sys/kernel" ]; do
+		umount $DEST/sys
+		sleep 2
+	done
+	while [ -e "$DEST/dev/pts/0" ]; do
+		umount $DEST/dev/pts
+		sleep 2
+	done
+	while [ -e "$DEST/dev/cpu" ]; do
+		umount $DEST/dev
+		sleep 2
+	done
 	if [ -d "$TEMP" ]; then
 		rm -rf "$TEMP"
 	fi
@@ -66,15 +87,18 @@ UNTAR="bsdtar -xpf"
 METHOD="download"
 
 case $DISTRO in
-	arch)
+	arch|arch-lcd)
 		ROOTFS="http://archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz"
 		;;
-	xenial)
-		ROOTFS="http://cdimage.ubuntu.com/ubuntu-base/releases/16.04.1/release/ubuntu-base-16.04.1-base-arm64.tar.gz"
+	xenial|xenial-lcd)
+		ROOTFS="http://cdimage.ubuntu.com/ubuntu-base/releases/16.04.2/release/ubuntu-base-16.04.2-base-arm64.tar.gz"
 		;;
-	sid|jessie)
+	sid|sid-lcd|jessie|jessie-lcd)
 		ROOTFS="${DISTRO}-base-arm64.tar.gz"
 		METHOD="debootstrap"
+		;;
+	opensuse|opensuse-lcd)
+		ROOTFS="http://download.opensuse.org/ports/aarch64/factory/images/openSUSE-Tumbleweed-ARM-JeOS.aarch64-rootfs.aarch64-Current.tbz"
 		;;
 	*)
 		echo "Unknown distribution: $DISTRO"
@@ -143,6 +167,10 @@ cat > "$DEST/usr/sbin/policy-rc.d" <<EOF
 exit 101
 EOF
 chmod a+x "$DEST/usr/sbin/policy-rc.d"
+
+# Mount dev
+mount --bind /dev $DEST/dev
+mount --bind /dev/pts $DEST/dev/pts
 
 do_chroot() {
 	cmd="$@"
@@ -288,7 +316,7 @@ add_asound_state() {
 
 # Run stuff in new system.
 case $DISTRO in
-	arch)
+	arch|arch-lcd)
 		# Cleanup preinstalled Kernel
 		mv "$DEST/etc/resolv.conf" "$DEST/etc/resolv.conf.dist"
 		cp /etc/resolv.conf "$DEST/etc/resolv.conf"
@@ -309,25 +337,29 @@ locale-gen
 localectl set-locale LANG=en_US.utf8
 localectl set-keymap us
 echo -e "\n[pine64]\nServer = https://andreascarpino.it/pine64/" >> /etc/pacman.conf
-pacman -Sy --noconfirm sunxi-disp-tool
-yes | pacman -Scc
 EOF
 		chmod +x "$DEST/second-phase"
 		do_chroot /second-phase
+		if [ "$DISTRO" = "arch" ]; then
+			do_chroot pacman -Sy --noconfirm sunxi-disp-tool
+		fi
+		do_chroot "yes | pacman -Scc"
 		sed -i 's|#CheckSpace|CheckSpace|' "$DEST/etc/pacman.conf"
 		rm -f "$DEST/etc/resolv.conf"
 		mv "$DEST/etc/resolv.conf.dist" "$DEST/etc/resolv.conf"
 		;;
-	xenial|sid|jessie)
+	xenial|xenial-lcd|sid|sid-lcd|jessie|jessie-lcd)
 		rm "$DEST/etc/resolv.conf"
 		cp /etc/resolv.conf "$DEST/etc/resolv.conf"
-		if [ "$DISTRO" = "xenial" ]; then
+		if [ "$DISTRO" = "xenial" -o "$DISTRO" = "xenial-lcd"]; then
 			DEB=ubuntu
 			DEBUSER=ubuntu
 			DEBUSERPW=ubuntu
 			EXTRADEBS="software-properties-common zram-config ubuntu-minimal"
 			ADDPPACMD="apt-add-repository -y ppa:longsleep/ubuntu-pine64-flavour-makers"
-			DISPTOOLCMD="apt-get -y install sunxi-disp-tool"
+			if [ "$DISTRO" = "xenial" ]; then
+				DISPTOOLCMD="apt-get -y install sunxi-disp-tool"
+			fi
 		elif [ "$DISTRO" = "sid" -o "$DISTRO" = "jessie" ]; then
 			DEB=debian
 			DEBUSER=debian
@@ -389,6 +421,86 @@ EOF
 		rm -f "$DEST/etc/resolv.conf"
 		rm -f "$DEST"/etc/ssh/ssh_host_*
 		do_chroot ln -s /run/resolvconf/resolv.conf /etc/resolv.conf
+		;;
+	opensuse|opensuse-lcd)
+		cat > "$DEST/etc/resolv.conf" << "EOF"
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+EOF
+
+		cat > "$DEST/second-phase" <<EOF
+#!/bin/sh
+zypper remove -y kernel-default kernel-firmware
+zypper update
+zypper install -y dosfstools rfkill newt xterm patterns-openSUSE-yast2_basis
+zypper ar -f http://files.pine64.org/opensuse/repository "Pine64 support packages for openSUSE"
+echo
+echo "###########################################################################"
+echo "# For the prompt below, please answer it with 'a' for optimum performance #"
+echo "###########################################################################"
+echo
+zypper refresh
+passwd << END
+pine64root
+pine64root
+END
+
+useradd -m pine64
+passwd pine64 << END
+pine64linux
+pine64linux
+END
+
+groupadd sudo
+groupadd adm
+groupadd plugdev
+usermod -a -G sudo,adm,input,video,plugdev pine64
+zypper clean -a
+EOF
+		chmod +x "$DEST/second-phase"
+		do_chroot /second-phase
+		cat > "$DEST/etc/hostname" <<EOF
+pine64
+EOF
+		cat > "$DEST/etc/hosts" <<EOF
+127.0.0.1 localhost
+127.0.1.1 pine64
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+EOF
+		# Install platform scripts
+		mkdir -p "$DEST/usr/local/sbin"
+		cp -av ./platform-scripts/* "$DEST/usr/local/sbin"
+		wget http://files.pine64.org/opensuse/tools/pine64-config/opensuse/pine64-config.sh -O $DEST/usr/local/sbin/pine64-config.sh		
+		chown root.root "$DEST/usr/local/sbin/"*
+		chmod 755 "$DEST/usr/local/sbin/"*		
+
+		# Need this patch to fix the update scripts for the next step in openSUSE
+		sed -i 's/ETag/etag/g' $DEST/usr/local/sbin/pine64_update_kernel.sh
+		sed -i 's/ETag/etag/g' $DEST/usr/local/sbin/pine64_update_uboot.sh
+
+		# Set Kernel and U-boot update version
+		do_chroot /usr/bin/env MARK_ONLY=1 /usr/local/sbin/pine64_update_kernel.sh
+		do_chroot /usr/bin/env MARK_ONLY=1 /usr/local/sbin/pine64_update_uboot.sh
+		
+		# Remove scripts that are incompatible with openSUSE or already provided by pine64-config
+		rm $DEST/usr/local/sbin/install_mate_desktop.sh
+		rm $DEST/usr/local/sbin/pine64_update_kernel.sh
+		rm $DEST/usr/local/sbin/pine64_update_uboot.sh
+
+		add_mackeeper_service
+		add_corekeeper_service
+		add_ssh_keygen_service
+		add_disp_udev_rules
+		add_wifi_module_autoload
+		add_asound_state
+		sed -i 's|After=rc.local.service|#\0|;' "$DEST/usr/lib/systemd/system/serial-getty@.service"
+		rm -f "$DEST/second-phase"
 		;;
 	*)
 		;;

--- a/simpleimage/make_simpleimage.sh
+++ b/simpleimage/make_simpleimage.sh
@@ -17,12 +17,21 @@
 
 set -e
 
-out="$1"
-disk_size="$2"
+type="$1"
+out="$2"
 kernel_tarball="$3"
+disk_size="$4"
 
-if [ -z "$out" ]; then
-	echo "Usage: $0 <image-file.img> [disk size in MiB] [<kernel-tarball>]"
+if [ -z "$out" -o -z "$type" -o -z "$kernel_tarball" ]; then
+	echo "Usage: $0 <image-type> <image-file.img> <kernel-tarball-or-folder> [disk size in MiB]"
+	echo ""
+	echo "Image type:"
+	echo ""
+	echo "pine64      - Pine A64"
+	echo "pine64lcd   - Pine A64 with LCD"
+	echo "sopine      - SoPine A64"
+	echo "pinebook    - Pinebook"
+	echo ""
 	exit 1
 fi
 
@@ -35,9 +44,19 @@ if [ "$disk_size" -lt 60 ]; then
 	exit 2
 fi
 
+if [ $type = "pine64" -o $type = "pine64lcd" ]; then
+	boot0="../blobs/boot0.bin"
+elif [ $type = "sopine" ]; then
+	boot0="../blobs/boot0so.bin"
+elif [ $type = "pinebook" ]; then
+	boot0="../blobs/boot0book.bin"
+else
+	echo "Invalid image type specified"
+	exit 3
+fi
+
 echo "Creating image $out of size $disk_size MiB ..."
 
-boot0="../blobs/boot0.bin"
 uboot="../build/u-boot-with-dtb.bin"
 kernel="../build"
 
@@ -55,6 +74,14 @@ if [ -n "$kernel_tarball" ]; then
 	tar -C $temp -xJf "$kernel_tarball"
 	kernel=$temp/boot
 	mv $temp/boot/uEnv.txt.in $temp/boot/uEnv.txt
+fi
+
+if [ $type = "pine64lcd" ]; then
+	echo "pine64_model=pine64-plus-lcd" >> $temp/boot/uEnv.txt
+elif [ $type = "sopine" ]; then
+	echo "pine64_model=pine64-so" >> $temp/boot/uEnv.txt
+elif [ $type = "pinebook" ]; then
+	echo "pine64_model=pinebook" >> $temp/boot/uEnv.txt
 fi
 
 boot0_position=8      # KiB


### PR DESCRIPTION
- Added dts for pine64 lcd
- build-pine64-image.sh now able to generate different types of images for different configurations
- build-pine64-image.sh will attempt to build a simpleimage if none is provided
- Generated image size reduced to 1440MB to reduce the time needed to write the image
- Generated kernel tarballs now include the pine64 lcd dts and the pinebook dts (developer variant)
- Added the ability to generate opensuse images

Signed-off-by: Ben Tinner <bentinner@yahoo.com.sg>