### PR TITLE
Create chromium-browser directory if not present

### DIFF
--- a/simpleimage/platform-scripts/install_desktop.sh
+++ b/simpleimage/platform-scripts/install_desktop.sh
@@ -114,6 +114,9 @@ export VDPAU_DRIVER=sunxi
 EOF
 fi
 
+# Create directory if not present
+[ -d /etc/chromium-browser ] || mkdir /etc/chromium-browser
+
 # Set some default parameters for chromium.
 if [ ! -e "/etc/chromium-browser/default" ]; then
 	cat > "/etc/chromium-browser/default" <<EOF


### PR DESCRIPTION
It appears that the chromium-browser folder is not *always* present when this script runs, so create it if missing. Fixes #65 